### PR TITLE
Add PSR4 namespace check for classes, traits, interfaces.

### DIFF
--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspector.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspector.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class AutoloadabilityInspector
+{
+    /**
+     * @var string
+     */
+    protected string $baseDirectory;
+
+    /**
+     * @var string
+     */
+    protected string $namespacePrefix;
+
+    /**
+     * @param string $baseDirectory
+     * @param string $namespacePrefix
+     */
+    public function __construct(string $baseDirectory, string $namespacePrefix)
+    {
+        $this->baseDirectory = rtrim($baseDirectory, '/') . '/';
+        $this->namespacePrefix = rtrim($namespacePrefix, '\\') . '\\';
+    }
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\InspectionResult
+     */
+    public function inspect(
+        ClassFileUnderInspection $classFile,
+    ): InspectionResult {
+        return $this->classFileIsUnderBaseDirectory($classFile) ?
+            $this->inspectAutoloadability($classFile) :
+            new PSR4UnrelatedClass();
+    }
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return bool
+     */
+    protected function classFileIsUnderBaseDirectory(
+        ClassFileUnderInspection $classFile,
+    ): bool {
+        return strpos($classFile->getFileName(), $this->baseDirectory) === 0;
+    }
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\InspectionResult
+     */
+    protected function inspectAutoloadability(
+        ClassFileUnderInspection $classFile,
+    ): InspectionResult {
+        $expectedClassName = $this->guessExpectedClassName($classFile);
+        $actualClassName = $classFile->getClassName();
+
+        return $expectedClassName === $actualClassName ?
+            new AutoloadableClass() :
+            new NonAutoloadableClass($expectedClassName, $actualClassName);
+    }
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return string
+     */
+    protected function guessExpectedClassName(
+        ClassFileUnderInspection $classFile,
+    ): string {
+        $relativeFileName = $this->guessRelativeFileName($classFile);
+        $relativeClassName = $this->guessRelativeClassName($relativeFileName);
+
+        return $this->guessFullyQualifiedClassName($relativeClassName);
+    }
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return string
+     */
+    protected function guessRelativeFileName(
+        ClassFileUnderInspection $classFile,
+    ): string {
+        assert($this->directoryEndsWithSlash());
+        assert($this->classFileIsUnderBaseDirectory($classFile));
+
+        return substr(
+            $classFile->getFileName(),
+            strlen($this->baseDirectory),
+        );
+    }
+
+    /**
+     * @param string $relativeFileName
+     *
+     * @return string
+     */
+    protected function guessRelativeClassName(string $relativeFileName): string
+    {
+        $basename = basename($relativeFileName);
+        $filename = pathinfo($relativeFileName, \PATHINFO_FILENAME);
+        $dirname = $basename === $relativeFileName ?
+            '' :
+            pathinfo($relativeFileName, \PATHINFO_DIRNAME) . '/';
+
+        return str_replace('/', '\\', $dirname) . $filename;
+    }
+
+    /**
+     * @param string $relativeClassName
+     *
+     * @return string
+     */
+    protected function guessFullyQualifiedClassName(
+        string $relativeClassName,
+    ): string {
+        assert($this->namespaceEndsWithBackslash());
+
+        return $this->namespacePrefix . $relativeClassName;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function directoryEndsWithSlash(): bool
+    {
+        return substr($this->baseDirectory, -1) === '/';
+    }
+
+    /**
+     * @return bool
+     */
+    protected function namespaceEndsWithBackslash(): bool
+    {
+        return substr($this->namespacePrefix, -1) === '\\';
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectors.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectors.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class AutoloadabilityInspectors
+{
+    /**
+     * @var array<\PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspector>
+     */
+    protected array $inspectors = [];
+
+    /**
+     * @param \PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspector ...$inspectors
+     */
+    public function __construct(AutoloadabilityInspector ...$inspectors)
+    {
+        $this->inspectors = $inspectors;
+    }
+
+    /**
+     * @noinspection MultipleReturnStatementsInspection
+     *
+     * @param \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection $classFile
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\InspectionResult
+     */
+    public function inspect(
+        ClassFileUnderInspection $classFile,
+    ): InspectionResult {
+        foreach ($this->inspectors as $inspector) {
+            $result = $inspector->inspect($classFile);
+
+            if ($result->isPsr4RelatedClass()) {
+                return $result;
+            }
+        }
+
+        return new PSR4UnrelatedClass();
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
@@ -58,6 +58,7 @@ class AutoloadabilityInspectorsFactory
         }
         $psr4Directories = [];
 
+        $base = dirname($filename) . '/';
         if (isset($data['autoload']['psr-4'])) {
             foreach ($data['autoload']['psr-4'] as $namespace => $dirs) {
                 if (!is_array($dirs)) {
@@ -65,7 +66,7 @@ class AutoloadabilityInspectorsFactory
                 }
                 foreach ($dirs as $dir) {
                     $psr4Directories[] = new AutoloadabilityInspector(
-                        dirname($filename) . '/' . $dir,
+                        $base . $dir,
                         $namespace,
                     );
                 }
@@ -79,7 +80,7 @@ class AutoloadabilityInspectorsFactory
                 }
                 foreach ($dirs as $dir) {
                     $psr4Directories[] = new AutoloadabilityInspector(
-                        dirname($filename) . '/' . $dir,
+                        $base . $dir,
                         $namespace,
                     );
                 }

--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
@@ -65,7 +65,7 @@ class AutoloadabilityInspectorsFactory
                     $dirs = [$dirs];
                 }
                 foreach ($dirs as $dir) {
-                    $psr4Directories[] = new AutoloadabilityInspector(
+                    $psr4Directories[$dir] = new AutoloadabilityInspector(
                         $base . $dir,
                         $namespace,
                     );
@@ -79,13 +79,15 @@ class AutoloadabilityInspectorsFactory
                     $dirs = [$dirs];
                 }
                 foreach ($dirs as $dir) {
-                    $psr4Directories[] = new AutoloadabilityInspector(
+                    $psr4Directories[$dir] = new AutoloadabilityInspector(
                         $base . $dir,
                         $namespace,
                     );
                 }
             }
         }
+
+        krsort($psr4Directories);
 
         return new AutoloadabilityInspectors(...$psr4Directories);
     }

--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadabilityInspectorsFactory.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+class AutoloadabilityInspectorsFactory
+{
+    /**
+     * @param string|null $basePath
+     * @param string $composerJsonPath
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspectors
+     */
+    public static function create(
+        ?string $basePath,
+        string $composerJsonPath,
+    ): AutoloadabilityInspectors {
+        $resolvedComposerJsonPath = static::resolveComposerJsonPath(
+            $basePath,
+            $composerJsonPath,
+        );
+        static::assertFileExists($resolvedComposerJsonPath);
+        static::assertFileIsReadable($resolvedComposerJsonPath);
+
+        return static::getPsr4Directories($resolvedComposerJsonPath);
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @throws \RuntimeException
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspectors
+     */
+    protected static function getPsr4Directories(
+        string $filename,
+    ): AutoloadabilityInspectors {
+        $contents = file_get_contents($filename);
+
+        if ($contents === false) {
+            throw new RuntimeException("Unable to read file: {$filename}");
+        }
+        $data = json_decode($contents, true);
+
+        if (!is_array($data)) {
+            throw new RuntimeException(
+                "Unable to decode json: {$filename}",
+            );
+        }
+        $psr4Directories = [];
+
+        if (isset($data['autoload']['psr-4'])) {
+            foreach ($data['autoload']['psr-4'] as $namespace => $dirs) {
+                if (!is_array($dirs)) {
+                    $dirs = [$dirs];
+                }
+                foreach ($dirs as $dir) {
+                    $psr4Directories[] = new AutoloadabilityInspector(
+                        dirname($filename) . '/' . $dir,
+                        $namespace,
+                    );
+                }
+            }
+        }
+
+        if (isset($data['autoload-dev']['psr-4'])) {
+            foreach ($data['autoload-dev']['psr-4'] as $namespace => $dirs) {
+                if (!is_array($dirs)) {
+                    $dirs = [$dirs];
+                }
+                foreach ($dirs as $dir) {
+                    $psr4Directories[] = new AutoloadabilityInspector(
+                        dirname($filename) . '/' . $dir,
+                        $namespace,
+                    );
+                }
+            }
+        }
+
+        return new AutoloadabilityInspectors(...$psr4Directories);
+    }
+
+    /**
+     * @param string|null $basePath
+     * @param string $composerJsonPath
+     *
+     * @return string
+     */
+    protected static function resolveComposerJsonPath(
+        ?string $basePath,
+        string $composerJsonPath,
+    ): string {
+        return $basePath === null ?
+            $composerJsonPath :
+            $basePath . '/' . $composerJsonPath;
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected static function assertFileExists(string $filename): void
+    {
+        if (!is_file($filename)) {
+            throw new InvalidArgumentException(
+                "composer.json file not found: {$filename}",
+            );
+        }
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    protected static function assertFileIsReadable(string $filename): void
+    {
+        if (!is_readable($filename)) {
+            throw new InvalidArgumentException(
+                "composer.json file is not readable: {$filename}",
+            );
+        }
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/AutoloadableClass.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/AutoloadableClass.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class AutoloadableClass implements InspectionResult
+{
+    /**
+     * @return bool
+     */
+    public function isAutoloadable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPsr4RelatedClass(): bool
+    {
+        return true;
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/ClassFileUnderInspection.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/ClassFileUnderInspection.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class ClassFileUnderInspection
+{
+    /**
+     * @var string
+     */
+    protected string $fileName;
+
+    /**
+     * @var string
+     */
+    protected string $className;
+
+    /**
+     * @param string $fileName
+     * @param string $className
+     */
+    public function __construct(string $fileName, string $className)
+    {
+        $this->fileName = $fileName;
+        $this->className = ltrim($className, '\\');
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/InspectionResult.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/InspectionResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+interface InspectionResult
+{
+    /**
+     * @return bool
+     */
+    public function isAutoloadable(): bool;
+
+    /**
+     * @return bool
+     */
+    public function isPsr4RelatedClass(): bool;
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/NonAutoloadableClass.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/NonAutoloadableClass.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class NonAutoloadableClass implements InspectionResult
+{
+    /**
+     * @var string
+     */
+    protected string $expectedClassName;
+
+    /**
+     * @var string
+     */
+    protected string $actualClassName;
+
+    /**
+     * @param string $expectedClassName
+     * @param string $actualClassName
+     */
+    public function __construct(
+        string $expectedClassName,
+        string $actualClassName,
+    ) {
+        $this->expectedClassName = $expectedClassName;
+        $this->actualClassName = $actualClassName;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAutoloadable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPsr4RelatedClass(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedClassName(): string
+    {
+        return $this->expectedClassName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActualClassName(): string
+    {
+        return $this->actualClassName;
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4/PSR4UnrelatedClass.php
+++ b/PhpCollective/Sniffs/Classes/Psr4/PSR4UnrelatedClass.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes\Psr4;
+
+class PSR4UnrelatedClass implements InspectionResult
+{
+    /**
+     * @return bool
+     */
+    public function isAutoloadable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPsr4RelatedClass(): bool
+    {
+        return false;
+    }
+}

--- a/PhpCollective/Sniffs/Classes/Psr4Sniff.php
+++ b/PhpCollective/Sniffs/Classes/Psr4Sniff.php
@@ -98,7 +98,7 @@ class Psr4Sniff implements Sniff
             $this->initialization = static::INITIALIZATION_FAILURE;
             $this->autoloadabilityInspectors =
                 AutoloadabilityInspectorsFactory::create(
-                    $config->getSettings()['basepath'],
+                    $config->getSettings()['basepath'] ?: getcwd(),
                     $this->composerJsonPath,
                 );
             $this->initialization = static::INITIALIZED;

--- a/PhpCollective/Sniffs/Classes/Psr4Sniff.php
+++ b/PhpCollective/Sniffs/Classes/Psr4Sniff.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\Classes;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspectors;
+use PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspectorsFactory;
+use PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection;
+use PhpCollective\Sniffs\Classes\Psr4\NonAutoloadableClass;
+use RuntimeException;
+use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class Psr4Sniff implements Sniff
+{
+    /**
+     * @var string
+     */
+    public const CODE_INCORRECT_CLASS_NAME = 'IncorrectClassName';
+
+    /**
+     * @var int
+     */
+    protected const INITIALIZED = 1;
+
+    /**
+     * @var int
+     */
+    protected const UNINITIALIZED = 0;
+
+    protected const INITIALIZATION_FAILURE = -1;
+
+    /**
+     * File path of "composer.json".
+     *
+     * This must be relative path to "--basepath" option of phpcs command.
+     *
+     * @var string
+     */
+    public string $composerJsonPath = 'composer.json';
+
+    /**
+     * @var int
+     */
+    protected int $initialization = self::UNINITIALIZED;
+
+    /**
+     * @var \PhpCollective\Sniffs\Classes\Psr4\AutoloadabilityInspectors
+     */
+    protected AutoloadabilityInspectors $autoloadabilityInspectors;
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [\T_CLASS, \T_INTERFACE, \T_TRAIT];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $typePointer): void
+    {
+        $this->initializeThisSniffIfNotYet($phpcsFile->config);
+
+        if ($this->initialization === static::INITIALIZATION_FAILURE) {
+            return;
+        }
+
+        $classFile = $this->getClassFileOf($phpcsFile, $typePointer);
+        $result = $this->autoloadabilityInspectors->inspect($classFile);
+
+        if ($result instanceof NonAutoloadableClass) {
+            $this->addError($phpcsFile, $result, $typePointer);
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Config $config
+     *
+     * @return void
+     */
+    protected function initializeThisSniffIfNotYet(Config $config): void
+    {
+        if ($this->initialization === static::UNINITIALIZED) {
+            $this->initialization = static::INITIALIZATION_FAILURE;
+            $this->autoloadabilityInspectors =
+                AutoloadabilityInspectorsFactory::create(
+                    $config->getSettings()['basepath'],
+                    $this->composerJsonPath,
+                );
+            $this->initialization = static::INITIALIZED;
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $typePointer
+     *
+     * @return \PhpCollective\Sniffs\Classes\Psr4\ClassFileUnderInspection
+     */
+    protected function getClassFileOf(
+        File $phpcsFile,
+        int $typePointer,
+    ): ClassFileUnderInspection {
+        return new ClassFileUnderInspection(
+            $phpcsFile->getFilename(),
+            ClassHelper::getFullyQualifiedName($phpcsFile, $typePointer),
+        );
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param \PhpCollective\Sniffs\Classes\Psr4\NonAutoloadableClass $result
+     * @param int $typePointer
+     *
+     * @throws \RuntimeException
+     *
+     * @return void
+     */
+    protected function addError(
+        File $phpcsFile,
+        NonAutoloadableClass $result,
+        int $typePointer,
+    ): void {
+        $stackPtr = $this->getClassNameDeclarationPosition($phpcsFile, $typePointer);
+        if ($stackPtr === null) {
+            throw new RuntimeException('Cannot find class declaration position');
+        }
+
+        $phpcsFile->addError(
+            sprintf(
+                'Class name is not compliant with PSR-4 configuration. ' .
+                'It should be `%s` instead of `%s`.',
+                $result->getExpectedClassName(),
+                $result->getActualClassName(),
+            ),
+            $stackPtr,
+            static::CODE_INCORRECT_CLASS_NAME,
+        );
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $typePointer
+     *
+     * @return int|null
+     */
+    protected function getClassNameDeclarationPosition(
+        File $phpcsFile,
+        int $typePointer,
+    ): ?int {
+        return TokenHelper::findNext($phpcsFile, \T_STRING, $typePointer + 1);
+    }
+}

--- a/docs/sniffs.md
+++ b/docs/sniffs.md
@@ -47,6 +47,7 @@ PhpCollective (78 sniffs)
 - PhpCollective.Classes.MethodDeclaration
 - PhpCollective.Classes.MethodTypeHint
 - PhpCollective.Classes.PropertyDefaultValue
+- PhpCollective.Classes.Psr4
 - PhpCollective.Classes.ReturnTypeHint
 - PhpCollective.Classes.SelfAccessor
 - PhpCollective.Commenting.Attributes


### PR DESCRIPTION
Try to port not maintained https://github.com/suin/phpcs-psr4-sniff

BUT:
It doesn't quite seem to work

If I have a namespace of 

    Foo => src/Foo

defined, It does not report issues like

    Foo\Bar\Baz => src/Foo/Baaaaa/Baz

Which it should IMO
