### PR TITLE
Fix up deprecations.

### DIFF
--- a/PhpCollective/ruleset.xml
+++ b/PhpCollective/ruleset.xml
@@ -205,7 +205,11 @@
             </property>
         </properties>
     </rule>
-    <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
+    <rule ref="Generic.Formatting.SpaceAfterCast">
+        <properties>
+            <property name="spacing" value="0"/>
+        </properties>
+    </rule>
 
     <rule ref="Squiz.PHP.Eval"/>
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
@@ -240,7 +244,7 @@
     <rule ref="Squiz.Scope.MethodScope"/>
     <rule ref="Squiz.Scope.StaticThisUsage"/>
 
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
 

--- a/docs/sniffs.md
+++ b/docs/sniffs.md
@@ -3,7 +3,7 @@
 
 The PhpCollectiveStrict standard contains 225 sniffs
 
-Generic (25 sniffs)
+Generic (26 sniffs)
 -------------------
 - Generic.Arrays.DisallowLongArraySyntax
 - Generic.CodeAnalysis.ForLoopShouldBeWhileLoop
@@ -16,7 +16,7 @@ Generic (25 sniffs)
 - Generic.Files.LineEndings
 - Generic.Files.LineLength
 - Generic.Formatting.DisallowMultipleStatements
-- Generic.Formatting.NoSpaceAfterCast
+- Generic.Formatting.SpaceAfterCast
 - Generic.Functions.FunctionCallArgumentSpacing
 - Generic.NamingConventions.UpperCaseConstantName
 - Generic.PHP.DeprecatedFunctions
@@ -29,6 +29,7 @@ Generic (25 sniffs)
 - Generic.PHP.NoSilencedErrors
 - Generic.WhiteSpace.DisallowTabIndent
 - Generic.WhiteSpace.IncrementDecrementSpacing
+- Generic.WhiteSpace.LanguageConstructSpacing
 - Generic.WhiteSpace.ScopeIndent
 
 PEAR (4 sniffs)
@@ -223,7 +224,7 @@ SlevomatCodingStandard (55 sniffs)
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 - SlevomatCodingStandard.Whitespaces.DuplicateSpaces
 
-Squiz (28 sniffs)
+Squiz (27 sniffs)
 -----------------
 - Squiz.Arrays.ArrayBracketSpacing
 - Squiz.Classes.LowercaseClassKeywords
@@ -247,7 +248,6 @@ Squiz (28 sniffs)
 - Squiz.WhiteSpace.CastSpacing
 - Squiz.WhiteSpace.ControlStructureSpacing
 - Squiz.WhiteSpace.FunctionOpeningBraceSpace
-- Squiz.WhiteSpace.LanguageConstructSpacing
 - Squiz.WhiteSpace.LogicalOperatorSpacing
 - Squiz.WhiteSpace.ScopeClosingBrace
 - Squiz.WhiteSpace.ScopeKeywordSpacing


### PR DESCRIPTION
Resolves
```
WARNING: The code-sniffer standard uses 2 deprecated sniffs
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  Generic.Formatting.NoSpaceAfterCast
   This sniff has been deprecated since v3.4.0 and will be removed in v4.0.0. Use the Generic.Formatting.SpaceAfterCast sniff with the $spacing property set to 0 instead.
-  Squiz.WhiteSpace.LanguageConstructSpacing
   This sniff has been deprecated since v3.3.0 and will be removed in v4.0.0. Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.
```