### PR TITLE
Add PipeOperatorSpacingSniff for PHP 8.5 pipe operator

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Ensures proper spacing around the pipe operator (|>) - a PHP 8.5 feature.
+ *
+ * The pipe operator allows for more readable function chaining:
+ * $result = $input |> trim(...) |> strtolower(...);
+ */
+class PipeOperatorSpacingSniff implements Sniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function register(): array
+    {
+        return [T_BITWISE_OR];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check if this is part of a pipe operator (|>)
+        $nextNonWhitespace = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if (!$nextNonWhitespace || $tokens[$nextNonWhitespace]['code'] !== T_GREATER_THAN) {
+            return;
+        }
+
+        // Check if there's whitespace between | and >
+        if ($nextNonWhitespace !== $stackPtr + 1) {
+            $fix = $phpcsFile->addFixableError(
+                'Expected at least 1 space before ">"; 0 found',
+                $stackPtr,
+                'SpaceBetweenPipe',
+            );
+            if ($fix) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = $stackPtr + 1; $i < $nextNonWhitespace; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // Now check spacing around the pipe operator
+        $this->checkSpacingBefore($phpcsFile, $stackPtr);
+        $this->checkSpacingAfter($phpcsFile, $nextNonWhitespace);
+    }
+
+    /**
+     * Check that there's exactly one space before the pipe operator
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function checkSpacingBefore(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+        if (!$prevIndex) {
+            return;
+        }
+
+        // Check if we're at the start of a line
+        if ($tokens[$prevIndex]['line'] !== $tokens[$stackPtr]['line']) {
+            return;
+        }
+
+        if ($tokens[$stackPtr - 1]['code'] !== T_WHITESPACE) {
+            $message = 'Expected at least 1 space before "|"; 0 found';
+            $fix = $phpcsFile->addFixableError($message, $stackPtr, 'MissingBefore');
+            if ($fix) {
+                $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+            }
+        } else {
+            $content = $tokens[$stackPtr - 1]['content'];
+            if ($content !== ' ' && $tokens[$prevIndex]['line'] === $tokens[$stackPtr]['line']) {
+                $message = 'Expected 1 space before "|", but %d found';
+                $data = [strlen($content)];
+                $fix = $phpcsFile->addFixableError($message, $stackPtr, 'TooManyBefore', $data);
+                if ($fix) {
+                    $phpcsFile->fixer->replaceToken($stackPtr - 1, ' ');
+                }
+            }
+        }
+    }
+
+    /**
+     * Check that there's exactly one space after the pipe operator
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $greaterThanPtr Pointer to the > token
+     *
+     * @return void
+     */
+    protected function checkSpacingAfter(File $phpcsFile, int $greaterThanPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $greaterThanPtr + 1, null, true);
+        if (!$nextIndex) {
+            return;
+        }
+
+        // Check if next token is on a different line
+        if ($tokens[$nextIndex]['line'] !== $tokens[$greaterThanPtr]['line']) {
+            return;
+        }
+
+        if ($tokens[$greaterThanPtr + 1]['code'] !== T_WHITESPACE) {
+            $message = 'Expected at least 1 space after ">"; 0 found';
+            $fix = $phpcsFile->addFixableError($message, $greaterThanPtr, 'MissingAfter');
+            if ($fix) {
+                $phpcsFile->fixer->addContent($greaterThanPtr, ' ');
+            }
+        } else {
+            $content = $tokens[$greaterThanPtr + 1]['content'];
+            if ($content !== ' ' && $tokens[$nextIndex]['line'] === $tokens[$greaterThanPtr]['line']) {
+                $message = 'Expected 1 space after ">", but %d found';
+                $data = [strlen($content)];
+                $fix = $phpcsFile->addFixableError($message, $greaterThanPtr, 'TooManyAfter', $data);
+                if ($fix) {
+                    $phpcsFile->fixer->replaceToken($greaterThanPtr + 1, ' ');
+                }
+            }
+        }
+    }
+}

--- a/tests/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\WhiteSpace;
+
+use PhpCollective\Sniffs\WhiteSpace\PipeOperatorSpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class PipeOperatorSpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testPipeOperatorSpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new PipeOperatorSpacingSniff(), 10, 10);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPipeOperatorSpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new PipeOperatorSpacingSniff(), 10);
+    }
+}

--- a/tests/_data/PipeOperatorSpacing/after.php
+++ b/tests/_data/PipeOperatorSpacing/after.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class PipeOperatorExample
+{
+    public function testPipeOperator(): string
+    {
+        $input = '  Hello World  ';
+
+        // Correct usage
+        $output = $input
+            |> trim(...)
+            |> strtolower(...);
+
+        // Missing spaces
+        $bad1 = $input |> trim(...) |> strtolower(...);
+
+        // Extra spaces before |
+        $bad2 = $input |> trim(...);
+
+        // Extra spaces after >
+        $bad3 = $input |> trim(...);
+
+        // Combination of issues
+        $bad4 = $input |> trim(...) |> strtolower(...);
+
+        return $output;
+    }
+}

--- a/tests/_data/PipeOperatorSpacing/before.php
+++ b/tests/_data/PipeOperatorSpacing/before.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class PipeOperatorExample
+{
+    public function testPipeOperator(): string
+    {
+        $input = '  Hello World  ';
+
+        // Correct usage
+        $output = $input
+            |> trim(...)
+            |> strtolower(...);
+
+        // Missing spaces
+        $bad1 = $input|>trim(...)|>strtolower(...);
+
+        // Extra spaces before |
+        $bad2 = $input  |> trim(...);
+
+        // Extra spaces after >
+        $bad3 = $input |>  trim(...);
+
+        // Combination of issues
+        $bad4 = $input|>trim(...)  |>  strtolower(...);
+
+        return $output;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds support for PHP 8.5 pipe operator (`|>`)
- Implements PipeOperatorSpacingSniff to enforce consistent spacing
- All violations are auto-fixable

## Changes
- Created `PhpCollective\Sniffs\WhiteSpace\PipeOperatorSpacingSniff`
- Added comprehensive test coverage
- Sniff enforces:
  - No space between `|` and `>`
  - Exactly one space before the pipe operator
  - Exactly one space after the pipe operator

## Example

### Before
```php
$result = $input|>trim(...)|>strtolower(...);
$result = $input  |>  trim(...);
```

### After
```php
$result = $input |> trim(...) |> strtolower(...);
$result = $input |> trim(...);
```

## Test Plan
- [x] Unit tests pass (10 errors detected and fixed)
- [x] Code style checks pass
- [x] Full test suite passes (84 tests)
- [x] Tested against PHP 8.5 pipe operator syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)