### PR TITLE
Add support for multi-line array shape annotations

### DIFF
--- a/tests/_data/DocBlockParam/after.php
+++ b/tests/_data/DocBlockParam/after.php
@@ -110,4 +110,55 @@ class DocBlockParamTestClass
     {
         // Should not error due to @inheritDoc
     }
+
+    /**
+     * Multi-line array shape annotation - should be parsed correctly
+     *
+     * @param array<string, array{
+     *   msgid: string,
+     *   msgid_plural: string|null,
+     *   msgctxt: string|null,
+     *   references: array<string>,
+     *   comments: array<string>
+     * }> $strings Extracted strings
+     *
+     * @return void
+     */
+    public function multiLineArrayShape(array $strings): void
+    {
+        // Should not error - multi-line array shape is valid
+    }
+
+    /**
+     * Multi-line with multiple params - should be parsed correctly
+     *
+     * @param string $name The name
+     * @param array{
+     *   id: int,
+     *   name: string,
+     *   meta?: array<string, mixed>
+     * } $data The data object
+     * @param bool $flag Optional flag
+     *
+     * @return void
+     */
+    public function multiLineWithMultipleParams(string $name, array $data, bool $flag = false): void
+    {
+        // Should not error - multi-line array shape with other params
+    }
+
+    /**
+     * Nested multi-line generics
+     *
+     * @param array<int, array<string, array{
+     *   key: string,
+     *   value: mixed
+     * }>> $nested Deeply nested structure
+     *
+     * @return void
+     */
+    public function nestedMultiLineGenerics(array $nested): void
+    {
+        // Should not error - deeply nested multi-line type
+    }
 }

--- a/tests/_data/DocBlockParam/before.php
+++ b/tests/_data/DocBlockParam/before.php
@@ -111,4 +111,55 @@ class DocBlockParamTestClass
     {
         // Should not error due to @inheritDoc
     }
+
+    /**
+     * Multi-line array shape annotation - should be parsed correctly
+     *
+     * @param array<string, array{
+     *   msgid: string,
+     *   msgid_plural: string|null,
+     *   msgctxt: string|null,
+     *   references: array<string>,
+     *   comments: array<string>
+     * }> $strings Extracted strings
+     *
+     * @return void
+     */
+    public function multiLineArrayShape(array $strings): void
+    {
+        // Should not error - multi-line array shape is valid
+    }
+
+    /**
+     * Multi-line with multiple params - should be parsed correctly
+     *
+     * @param string $name The name
+     * @param array{
+     *   id: int,
+     *   name: string,
+     *   meta?: array<string, mixed>
+     * } $data The data object
+     * @param bool $flag Optional flag
+     *
+     * @return void
+     */
+    public function multiLineWithMultipleParams(string $name, array $data, bool $flag = false): void
+    {
+        // Should not error - multi-line array shape with other params
+    }
+
+    /**
+     * Nested multi-line generics
+     *
+     * @param array<int, array<string, array{
+     *   key: string,
+     *   value: mixed
+     * }>> $nested Deeply nested structure
+     *
+     * @return void
+     */
+    public function nestedMultiLineGenerics(array $nested): void
+    {
+        // Should not error - deeply nested multi-line type
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `collectMultiLineType()` and `parseCollectedTypeContent()` helper methods to `CommentingTrait` for parsing type annotations that span multiple lines
- Updates `DocBlockParamSniff` to detect and properly handle multi-line array shape annotations
- Adds test cases covering various multi-line scenarios (nested generics, array shapes with multiple fields, mixed single and multi-line params)

This allows PHPDoc annotations like:
```php
/**
 * @param array<string, array{
 *   msgid: string,
 *   msgid_plural: string|null,
 *   msgctxt: string|null,
 *   references: array<string>,
 *   comments: array<string>
 * }> $strings Extracted strings
 */
```

## Test plan
- [x] Run existing `DocBlockParamSniffTest` - passes
- [x] Run `composer cs-check` - passes
- [x] Run `composer stan` - passes  
- [x] Run `composer test` - all 82 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)