### PR TITLE
Skip docblock requirement for constructors with fully typed parameters

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockSniff.php
@@ -134,6 +134,20 @@ class DocBlockSniff extends AbstractSniff
             return;
         }
 
+        // If all parameters are fully typed (including promoted properties), no docblock is needed
+        $allTyped = true;
+        foreach ($methodSignature as $param) {
+            if (empty($param['typehint'])) {
+                $allTyped = false;
+
+                break;
+            }
+        }
+
+        if ($allTyped) {
+            return;
+        }
+
         $phpcsFile->addError('Missing doc block for method', $stackPtr, 'ConstructDesctructMissingDocBlock');
     }
 


### PR DESCRIPTION
## Summary

When a constructor has all parameters fully typed (including promoted properties), a docblock is redundant since the types are self-documenting.

## Problem

This code triggers `ConstructDesctructMissingDocBlock`:

```php
class HtmlRenderer
{
    public function __construct(protected bool $xhtml = false)
    {
    }
}
```

Even though the signature is completely self-documenting:
- Parameter: `$xhtml`
- Type: `bool`
- Default: `false`
- Visibility: `protected` (promoted property)

## Solution

Skip the docblock requirement when all constructor parameters have type hints.

## Test cases

**Should NOT require docblock (all typed):**
```php
public function __construct(protected bool $xhtml = false) {}
public function __construct(string $name, int $age) {}
```

**Should still require docblock (untyped params):**
```php
public function __construct($name) {}
public function __construct(string $name, $age) {}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)