### PR TITLE
Fix param order when adding missing `@param` annotations

### DIFF
--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockParamSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockParamSniffTest.php
@@ -26,7 +26,8 @@ class DocBlockParamSniffTest extends TestCase
         // Line 74: ExtraParam - no params but has @param (fixable - can remove param)
         // Line 84: MissingType - missing type in @param (not fixable - needs manual type)
         // Line 87: SignatureMismatch - params don't match after missing type (not fixable)
-        $this->assertSnifferFindsErrors(new DocBlockParamSniff(), 8);
+        // Line 169: SignatureMismatch - middle param documented, need to add before and after (fixable)
+        $this->assertSnifferFindsErrors(new DocBlockParamSniff(), 9);
     }
 
     /**
@@ -34,10 +35,11 @@ class DocBlockParamSniffTest extends TestCase
      */
     public function testDocBlockParamFixer(): void
     {
-        // 3 fixable errors:
+        // 4 fixable errors:
         // Line 37: Can add missing @param
         // Line 64: Can remove extra @param
         // Line 74: Can remove @param when no params
-        $this->assertSnifferCanFixErrors(new DocBlockParamSniff(), 3);
+        // Line 169: Can add missing @param before and after existing param (order preserved)
+        $this->assertSnifferCanFixErrors(new DocBlockParamSniff(), 4);
     }
 }

--- a/tests/_data/DocBlockParam/after.php
+++ b/tests/_data/DocBlockParam/after.php
@@ -161,4 +161,16 @@ class DocBlockParamTestClass
     {
         // Should not error - deeply nested multi-line type
     }
+
+    /**
+     * Middle param documented - should add before and after
+     *
+     * @param Node $parent
+     * @param array<string> $lines
+     * @param int $indent
+     */
+    public function middleParamDocumented(Node $parent, array $lines, int $indent): void
+    {
+        // Should error: missing @param for $parent (before) and $indent (after)
+    }
 }

--- a/tests/_data/DocBlockParam/before.php
+++ b/tests/_data/DocBlockParam/before.php
@@ -162,4 +162,14 @@ class DocBlockParamTestClass
     {
         // Should not error - deeply nested multi-line type
     }
+
+    /**
+     * Middle param documented - should add before and after
+     *
+     * @param array<string> $lines
+     */
+    public function middleParamDocumented(Node $parent, array $lines, int $indent): void
+    {
+        // Should error: missing @param for $parent (before) and $indent (after)
+    }
 }


### PR DESCRIPTION
## Summary

When a docblock has only some `@param` annotations (e.g., only the middle parameter documented), the fixer was adding missing params in the wrong order.

**Before this fix:**
```php
/**
 * @param array<string> $lines
 */
public function foo(Node $parent, array $lines, int $indent): void
```

Would be "fixed" to:
```php
/**
 * @param array<string> $lines
 * @param int $indent
 * @param Node $parent
 */
```

**After this fix:**
```php
/**
 * @param Node $parent
 * @param array<string> $lines
 * @param int $indent
 */
```

## Changes

- Rewrote `canAddMissingParams()` to properly track positions and insert params in correct order
- Params before the first existing `@param` are queued and inserted before it
- Params after an existing `@param` are inserted after it
- Added test case for this scenario

## Test plan

- [x] New test case added for middle-param scenario
- [x] All existing tests pass (82 tests, 88 assertions)
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)