### PR TITLE
Fix: Preserve parameter order when inserting missing @param annotations

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockParamSniff.php
@@ -345,7 +345,9 @@ class DocBlockParamSniff extends AbstractSniff
                             }
                         }
 
-                        foreach ($pendingInserts as $pendingParam) {
+                        // Reverse the array since addContentBefore inserts before the same position
+                        // multiple times, which would reverse the order
+                        foreach (array_reverse($pendingInserts) as $pendingParam) {
                             $paramLine = $indent . '* @param ' . $pendingParam['type'] . ' ' . $pendingParam['variable'] . "\n";
                             $phpcsFile->fixer->addContentBefore($insertBeforeIndex, $paramLine);
                         }
@@ -398,7 +400,9 @@ class DocBlockParamSniff extends AbstractSniff
                 }
 
                 if ($insertBeforeIndex !== null) {
-                    foreach ($pendingInserts as $pendingParam) {
+                    // Reverse the array since addContentBefore inserts before the same position
+                    // multiple times, which would reverse the order
+                    foreach (array_reverse($pendingInserts) as $pendingParam) {
                         $paramLine = $indent . '* @param ' . $pendingParam['type'] . ' ' . $pendingParam['variable'] . "\n";
                         $phpcsFile->fixer->addContentBefore($insertBeforeIndex, $paramLine);
                     }


### PR DESCRIPTION
## Problem

When using phpcbf to fix missing `@param` annotations in a docblock, the parameters were being inserted in the wrong order.

For example, given this method:
```php
/**
 * @param string $context Context description
 */
private function getProfileConverter(string $profileName, bool $safeMode, string $context = 'article'): DjotConverter
```

The fix would produce:
```php
/**
 * @param bool $safeMode
 * @param string $profileName
 * @param string $context Context description
 */
```

Instead of the correct order:
```php
/**
 * @param string $profileName
 * @param bool $safeMode
 * @param string $context Context description
 */
```

## Root Cause

In `DocBlockParamSniff::canAddMissingParams()`, when multiple parameters need to be inserted before an existing parameter (or at the end of a docblock), they were processed using `addContentBefore()` in a forward loop. Since `addContentBefore()` inserts before the same position each time, the result is LIFO (last-in-first-out) order, reversing the parameters.

## Solution

Reverse the `$pendingInserts` array before iterating over it with `addContentBefore()`. This ensures parameters are inserted in the correct signature order.

## Impact

The incorrect parameter order was causing cascading issues with other sniffs:
- `DocBlockParamAllowDefaultValue` would detect type mismatches (e.g., `bool $safeMode` seems to be missing type `string`)
- `DocBlockParamTypeMismatch` would add incorrect union types to "fix" the mismatch
- This could lead to an infinite loop in phpcbf as sniffs kept trying to fix each other's changes

## Testing

The existing test case for `middleParamDocumented` already covers this scenario and passes with the fix.