### PR TITLE
Fix containsTypeArray to recognize array shape syntax

### DIFF
--- a/PhpCollective/Traits/CommentingTrait.php
+++ b/PhpCollective/Traits/CommentingTrait.php
@@ -183,7 +183,7 @@ trait CommentingTrait
     protected function containsTypeArray(array $docBlockTypes, string $iterableType = 'array'): bool
     {
         foreach ($docBlockTypes as $docBlockType) {
-            if (str_contains($docBlockType, '[]') || str_starts_with($docBlockType, $iterableType . '<')) {
+            if (str_contains($docBlockType, '[]') || str_starts_with($docBlockType, $iterableType . '<') || str_starts_with($docBlockType, $iterableType . '{')) {
                 return true;
             }
         }

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniffTest.php
@@ -17,7 +17,7 @@ class DocBlockParamAllowDefaultValueSniffTest extends TestCase
      */
     public function testDocBlockConstSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DocBlockParamAllowDefaultValueSniff(), 4);
+        $this->assertSnifferFindsErrors(new DocBlockParamAllowDefaultValueSniff(), 5);
     }
 
     /**

--- a/tests/_data/DocBlockParamAllowDefaultValue/after.php
+++ b/tests/_data/DocBlockParamAllowDefaultValue/after.php
@@ -77,4 +77,12 @@ class FixMe
     public function multipleUnion(int|string|null $value): void
     {
     }
+
+    /**
+     * @param array{msgid: string, msgid_plural: (string | null)}|null $array
+     * @return void
+     */
+    public function arrayShape(array $array = null): void
+    {
+    }
 }

--- a/tests/_data/DocBlockParamAllowDefaultValue/before.php
+++ b/tests/_data/DocBlockParamAllowDefaultValue/before.php
@@ -77,4 +77,12 @@ class FixMe
     public function multipleUnion(int|string|null $value): void
     {
     }
+
+    /**
+     * @param array{msgid: string, msgid_plural: string|null} $array
+     * @return void
+     */
+    public function arrayShape(array $array = null): void
+    {
+    }
 }


### PR DESCRIPTION
## Summary

- `containsTypeArray()` in `CommentingTrait` only checked for `array<` and `[]` patterns but not `array{` shape syntax
- This caused false positives in `DocBlockParamAllowDefaultValue` where `array{key: type}` was not recognized as satisfying the `array` typehint requirement, leading to unnecessary `|array` being appended
- Added test case for array shape syntax with nullable default