### PR TITLE
Add T_NAME_QUALIFIED support and PHP 8+ features to UseStatementSniff

### DIFF
--- a/PhpCollective/Sniffs/Namespaces/UseStatementSniff.php
+++ b/PhpCollective/Sniffs/Namespaces/UseStatementSniff.php
@@ -196,8 +196,13 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-        if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$nextIndex])) {
+        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+        if (
+            defined('T_NAME_FULLY_QUALIFIED') && (
+                $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$nextIndex]) ||
+                $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$nextIndex])
+            )
+        ) {
             $extractedUseStatement = ltrim($tokens[$nextIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return;
@@ -309,8 +314,13 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-        if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$prevIndex])) {
+        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+        if (
+            defined('T_NAME_FULLY_QUALIFIED') && (
+                $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$prevIndex]) ||
+                $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$prevIndex])
+            )
+        ) {
             $extractedUseStatement = ltrim($tokens[$prevIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return;
@@ -414,8 +424,13 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-        if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$classNameIndex])) {
+        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+        if (
+            defined('T_NAME_FULLY_QUALIFIED') && (
+                $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$classNameIndex]) ||
+                $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$classNameIndex])
+            )
+        ) {
             $extractedUseStatement = ltrim($tokens[$classNameIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return;
@@ -523,8 +538,13 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-        if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$classNameIndex])) {
+        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+        if (
+            defined('T_NAME_FULLY_QUALIFIED') && (
+                $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$classNameIndex]) ||
+                $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$classNameIndex])
+            )
+        ) {
             $extractedUseStatement = ltrim($tokens[$classNameIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return;
@@ -640,8 +660,13 @@ class UseStatementSniff implements Sniff
                 $startIndex = $i;
             }
 
-            // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-            if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$i])) {
+            // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+            if (
+                defined('T_NAME_FULLY_QUALIFIED') && (
+                    $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$i]) ||
+                    $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$i])
+                )
+            ) {
                 $extractedUseStatement = ltrim($tokens[$i]['content'], '\\');
                 if (!str_contains($extractedUseStatement, '\\')) {
                     continue;
@@ -757,8 +782,13 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED token
-        if (defined('T_NAME_FULLY_QUALIFIED') && $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$startIndex])) {
+        // PHP 8+: Check if it's a single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+        if (
+            defined('T_NAME_FULLY_QUALIFIED') && (
+                $this->isGivenKind(T_NAME_FULLY_QUALIFIED, $tokens[$startIndex]) ||
+                $this->isGivenKind(T_NAME_QUALIFIED, $tokens[$startIndex])
+            )
+        ) {
             $extractedUseStatement = ltrim($tokens[$startIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return;
@@ -861,9 +891,12 @@ class UseStatementSniff implements Sniff
             return;
         }
 
-        // Handle T_NAME_FULLY_QUALIFIED token (PHP CodeSniffer v4)
+        // Handle T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token (PHP CodeSniffer v4)
         $className = '';
-        if ($tokens[$startIndex]['code'] === T_NAME_FULLY_QUALIFIED) {
+        if (
+            $tokens[$startIndex]['code'] === T_NAME_FULLY_QUALIFIED ||
+            (defined('T_NAME_QUALIFIED') && $tokens[$startIndex]['code'] === T_NAME_QUALIFIED)
+        ) {
             $extractedUseStatement = ltrim($tokens[$startIndex]['content'], '\\');
             if (!str_contains($extractedUseStatement, '\\')) {
                 return; // Not a namespaced class
@@ -923,7 +956,7 @@ class UseStatementSniff implements Sniff
                 $phpcsFile->fixer->replaceToken($lastIndex, $addedUseStatement['alias']);
             }
         } else {
-            // PHP CodeSniffer v4: replace single T_NAME_FULLY_QUALIFIED token
+            // PHP CodeSniffer v4: replace single T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
             if ($addedUseStatement['alias'] !== null) {
                 $phpcsFile->fixer->replaceToken($startIndex, $addedUseStatement['alias']);
             } else {
@@ -1257,8 +1290,13 @@ class UseStatementSniff implements Sniff
                 break;
             }
 
-            // PHP 8+: Check for T_NAME_FULLY_QUALIFIED token
-            if (defined('T_NAME_FULLY_QUALIFIED') && $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED) {
+            // PHP 8+: Check for T_NAME_FULLY_QUALIFIED or T_NAME_QUALIFIED token
+            if (
+                defined('T_NAME_FULLY_QUALIFIED') && (
+                    $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED ||
+                    $tokens[$i]['code'] === T_NAME_QUALIFIED
+                )
+            ) {
                 $implements[] = [
                     'start' => $i,
                     'end' => $i,

--- a/tests/PhpCollective/Sniffs/Namespaces/UseStatementSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Namespaces/UseStatementSniffTest.php
@@ -15,12 +15,14 @@ use PhpCollective\Test\TestCase;
  *
  * This sniff has been updated with the following fixes ported from PSR2R NoInlineFullyQualifiedClassName:
  * - PHP 8+ T_NAME_FULLY_QUALIFIED token support in all check methods
+ * - PHP 8+ T_NAME_QUALIFIED token support for partially qualified names (e.g., Foo\Bar::method())
  * - PHP 8+ T_NAME_FULLY_QUALIFIED token support in parse() method for extends/implements
  * - shortName fallback when alias is null (prevents undefined replacements)
  * - str_contains() instead of deprecated strpos()
  *
  * The fixes ensure the sniff works correctly on PHP 8+ where inline FQCNs like \Foo\Bar\Class
  * are tokenized as a single T_NAME_FULLY_QUALIFIED token instead of multiple T_NS_SEPARATOR + T_STRING tokens.
+ * Partially qualified names like Foo\Bar\Class are tokenized as T_NAME_QUALIFIED.
  */
 class UseStatementSniffTest extends TestCase
 {
@@ -128,6 +130,28 @@ class UseStatementSniffTest extends TestCase
     public function testStaticFixer(): void
     {
         $this->prefix = 'static-';
+        $this->assertSnifferCanFixErrors(new UseStatementSniff());
+        $this->prefix = null;
+    }
+
+    /**
+     * Tests static call with PHP 8+ T_NAME_QUALIFIED (partially qualified name).
+     *
+     * @return void
+     */
+    public function testStaticQualifiedSniffer(): void
+    {
+        $this->prefix = 'static-qualified-';
+        $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testStaticQualifiedFixer(): void
+    {
+        $this->prefix = 'static-qualified-';
         $this->assertSnifferCanFixErrors(new UseStatementSniff());
         $this->prefix = null;
     }

--- a/tests/PhpCollective/Sniffs/Namespaces/UseStatementSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Namespaces/UseStatementSniffTest.php
@@ -243,4 +243,92 @@ class UseStatementSniffTest extends TestCase
         $this->assertSnifferCanFixErrors(new UseStatementSniff());
         $this->prefix = null;
     }
+
+    /**
+     * Tests PHP 8+ attribute with T_NAME_FULLY_QUALIFIED.
+     *
+     * @return void
+     */
+    public function testAttributeSniffer(): void
+    {
+        $this->prefix = 'attribute-';
+        $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testAttributeFixer(): void
+    {
+        $this->prefix = 'attribute-';
+        $this->assertSnifferCanFixErrors(new UseStatementSniff());
+        $this->prefix = null;
+    }
+
+    /**
+     * Tests PHP 8+ attribute with T_NAME_QUALIFIED (partially qualified name).
+     *
+     * @return void
+     */
+    public function testAttributeQualifiedSniffer(): void
+    {
+        $this->prefix = 'attribute-qualified-';
+        $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testAttributeQualifiedFixer(): void
+    {
+        $this->prefix = 'attribute-qualified-';
+        $this->assertSnifferCanFixErrors(new UseStatementSniff());
+        $this->prefix = null;
+    }
+
+    /**
+     * Tests PHP 8.1+ enum implements with T_NAME_FULLY_QUALIFIED.
+     *
+     * @return void
+     */
+    public function testEnumSniffer(): void
+    {
+        $this->prefix = 'enum-';
+        $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testEnumFixer(): void
+    {
+        $this->prefix = 'enum-';
+        $this->assertSnifferCanFixErrors(new UseStatementSniff());
+        $this->prefix = null;
+    }
+
+    /**
+     * Tests PHP 8.1+ enum implements with T_NAME_QUALIFIED (partially qualified name).
+     *
+     * @return void
+     */
+    public function testEnumQualifiedSniffer(): void
+    {
+        $this->prefix = 'enum-qualified-';
+        $this->assertSnifferFindsErrors(new UseStatementSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testEnumQualifiedFixer(): void
+    {
+        $this->prefix = 'enum-qualified-';
+        $this->assertSnifferCanFixErrors(new UseStatementSniff());
+        $this->prefix = null;
+    }
 }

--- a/tests/_data/UseStatement/attribute-after.php
+++ b/tests/_data/UseStatement/attribute-after.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+use Foo\Bar\SomeAttribute;
+
+// Tests PHP 8+ attribute with FQCN
+#[SomeAttribute]
+class FixMe
+{
+}

--- a/tests/_data/UseStatement/attribute-before.php
+++ b/tests/_data/UseStatement/attribute-before.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+// Tests PHP 8+ attribute with FQCN
+#[\Foo\Bar\SomeAttribute]
+class FixMe
+{
+}

--- a/tests/_data/UseStatement/attribute-qualified-after.php
+++ b/tests/_data/UseStatement/attribute-qualified-after.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+use Foo\Bar\SomeAttribute;
+
+// Tests PHP 8+ attribute with T_NAME_QUALIFIED (partially qualified name)
+#[SomeAttribute]
+class FixMe
+{
+}

--- a/tests/_data/UseStatement/attribute-qualified-before.php
+++ b/tests/_data/UseStatement/attribute-qualified-before.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+// Tests PHP 8+ attribute with T_NAME_QUALIFIED (partially qualified name)
+#[Foo\Bar\SomeAttribute]
+class FixMe
+{
+}

--- a/tests/_data/UseStatement/enum-after.php
+++ b/tests/_data/UseStatement/enum-after.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+use Foo\Bar\SomeInterface;
+
+// Tests PHP 8.1+ enum implements with FQCN
+enum FixMe: string implements SomeInterface
+{
+    case One = 'one';
+}

--- a/tests/_data/UseStatement/enum-before.php
+++ b/tests/_data/UseStatement/enum-before.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+// Tests PHP 8.1+ enum implements with FQCN
+enum FixMe: string implements \Foo\Bar\SomeInterface
+{
+    case One = 'one';
+}

--- a/tests/_data/UseStatement/enum-qualified-after.php
+++ b/tests/_data/UseStatement/enum-qualified-after.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+use Foo\Bar\SomeInterface;
+
+// Tests PHP 8.1+ enum implements with T_NAME_QUALIFIED (partially qualified name)
+enum FixMe: string implements SomeInterface
+{
+    case One = 'one';
+}

--- a/tests/_data/UseStatement/enum-qualified-before.php
+++ b/tests/_data/UseStatement/enum-qualified-before.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+// Tests PHP 8.1+ enum implements with T_NAME_QUALIFIED (partially qualified name)
+enum FixMe: string implements Foo\Bar\SomeInterface
+{
+    case One = 'one';
+}

--- a/tests/_data/UseStatement/static-qualified-after.php
+++ b/tests/_data/UseStatement/static-qualified-after.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+use App\Model\Enum\ActivityPhysioType;
+
+// Tests static call with PHP 8+ T_NAME_QUALIFIED (partially qualified name) - fixed in checkUseForStatic()
+class FixMe
+{
+    public function test()
+    {
+        if (ActivityPhysioType::Exercise !== $foo) {
+            return true;
+        }
+    }
+}

--- a/tests/_data/UseStatement/static-qualified-before.php
+++ b/tests/_data/UseStatement/static-qualified-before.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+// Tests static call with PHP 8+ T_NAME_QUALIFIED (partially qualified name) - fixed in checkUseForStatic()
+class FixMe
+{
+    public function test()
+    {
+        if (App\Model\Enum\ActivityPhysioType::Exercise !== $foo) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extends UseStatementSniff to handle partially qualified class names (e.g., `App\Model\Enum\Type::Value`)
- In PHP 8+, partially qualified names use `T_NAME_QUALIFIED` token, which was not handled before
- Now auto-fixes both fully qualified (`\Foo\Bar`) and partially qualified (`Foo\Bar`) names to use statements
- Adds support for PHP 8+ attributes (`#[\Foo\Bar]` and `#[Foo\Bar]`)
- Adds support for PHP 8.1+ enums with implements clause

### Before:
```php
if (App\Model\Enum\ActivityPhysioType::Exercise !== $foo) {
```

### After:
```php
use App\Model\Enum\ActivityPhysioType;

if (ActivityPhysioType::Exercise !== $foo) {
```

### Contexts now supported:
- `new Foo\Bar()` - partially qualified instantiation
- `Foo\Bar::method()` - partially qualified static calls (incl. enum cases)
- `$x instanceof Foo\Bar` - partially qualified instanceof
- `function foo(Foo\Bar $x)` - partially qualified parameter types
- `function foo(): Foo\Bar` - partially qualified return types
- `catch (Foo\Bar $e)` - partially qualified exceptions
- `protected Foo\Bar $prop` - partially qualified property types
- `class Foo extends Foo\Bar` - partially qualified extends
- `class Foo implements Foo\Bar` - partially qualified implements
- `enum Foo implements Foo\Bar` - PHP 8.1+ enum implements
- `#[Foo\Bar]` - PHP 8+ attribute FQCNs