### PR TITLE
Fix additional type safety issues in sniffs and traits

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockReturnNullSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockReturnNullSniff.php
@@ -193,10 +193,13 @@ class DocBlockReturnNullSniff implements Sniff
             }
 
             $nextIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $i + 1, null, true);
-            if (!$nextIndex) {
+            if ($nextIndex === false) {
                 continue;
             }
             $lastIndex = $phpcsFile->findNext(T_SEMICOLON, $nextIndex);
+            if ($lastIndex === false) {
+                continue;
+            }
 
             $type = '';
             for ($j = $nextIndex; $j < $lastIndex; $j++) {

--- a/PhpCollective/Sniffs/Commenting/DocBlockReturnVoidSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockReturnVoidSniff.php
@@ -469,7 +469,7 @@ class DocBlockReturnVoidSniff extends AbstractSniff
             $endIndex = $tokens[$stackPtr]['scope_opener'];
         }
 
-        if (!$endIndex) {
+        if ($endIndex === false) {
             return false;
         }
 

--- a/PhpCollective/Sniffs/Formatting/ArrayDeclarationSniff.php
+++ b/PhpCollective/Sniffs/Formatting/ArrayDeclarationSniff.php
@@ -184,8 +184,8 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $parenthesisCloseIndex = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($parenthesisCloseIndex + 1), null, true);
-                if (!$nextTokenIndex) {
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $parenthesisCloseIndex + 1, null, true);
+                if ($nextTokenIndex === false) {
                     break;
                 }
 
@@ -206,8 +206,8 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $bracketCloseIndex = $tokens[$nextToken]['bracket_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($bracketCloseIndex + 1), null, true);
-                if (!$nextTokenIndex) {
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $bracketCloseIndex + 1, null, true);
+                if ($nextTokenIndex === false) {
                     break;
                 }
 
@@ -227,8 +227,8 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 $nextToken = $tokens[$nextToken]['scope_closer'];
-                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-                if (!$nextTokenIndex) {
+                $nextTokenIndex = $phpcsFile->findNext(T_WHITESPACE, $nextToken + 1, null, true);
+                if ($nextTokenIndex === false) {
                     break;
                 }
 

--- a/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -37,9 +37,9 @@ class ImplicitCastSpacingSniff implements Sniff
             return;
         }
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
 
-        if ($nextIndex - $stackPtr === 1) {
+        if ($nextIndex === false || $nextIndex - $stackPtr === 1) {
             return;
         }
 
@@ -61,8 +61,8 @@ class ImplicitCastSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-        if ($tokens[$nextIndex]['code'] === T_VARIABLE) {
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if ($nextIndex !== false && $tokens[$nextIndex]['code'] === T_VARIABLE) {
             if ($nextIndex - $stackPtr === 1) {
                 return;
             }
@@ -77,8 +77,8 @@ class ImplicitCastSpacingSniff implements Sniff
             return;
         }
 
-        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if ($tokens[$prevIndex]['code'] === T_VARIABLE) {
+        $prevIndex = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+        if ($prevIndex !== false && $tokens[$prevIndex]['code'] === T_VARIABLE) {
             if ($stackPtr - $prevIndex === 1) {
                 return;
             }

--- a/PhpCollective/Traits/NamespaceTrait.php
+++ b/PhpCollective/Traits/NamespaceTrait.php
@@ -27,8 +27,8 @@ trait NamespaceTrait
         $tokens = $phpcsFile->getTokens();
 
         // Ignore USE keywords inside closures.
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-        if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+        $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             return true;
         }
 

--- a/PhpCollective/Traits/UseStatementsTrait.php
+++ b/PhpCollective/Traits/UseStatementsTrait.php
@@ -38,6 +38,9 @@ trait UseStatementsTrait
             }
 
             $semicolonIndex = $phpcsFile->findNext(T_SEMICOLON, $useStatementStartIndex + 1);
+            if ($semicolonIndex === false) {
+                continue;
+            }
             $useStatementEndIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $semicolonIndex - 1, null, true);
             if ($useStatementEndIndex === false) {
                 continue;


### PR DESCRIPTION
## Summary

Follow-up to PR #49, fixing additional type safety issues discovered during a second code review.

## Changes

| File | Issue Fixed |
|------|-------------|
| `DocBlockReturnVoidSniff.php` | `!$endIndex` check should be `=== false` |
| `DocBlockReturnNullSniff.php` | Missing `false` check on `findNext()` result before using in loop |
| `ArrayDeclarationSniff.php` | Three `!$nextTokenIndex` checks should be `=== false` |
| `ImplicitCastSpacingSniff.php` | Missing `false` checks before arithmetic and array access |
| `UseStatementsTrait.php` | Missing `false` check before using `$semicolonIndex - 1` |
| `NamespaceTrait.php` | Missing `false` check before array access `$tokens[$next]` |

## Why This Matters

When `findNext()` / `findPrevious()` returns `false` (not found):
- `!$var` treats both `false` and `0` as falsy - but `0` is a valid token index
- `$var - 1` on `false` becomes `-1` (since `false` → `0` in arithmetic)
- `$tokens[$var]` on `false` accesses `$tokens[0]` (the `<?php` token)

These bugs are theoretical (token 0 is always `<?php`), but fixing them improves code correctness.