### PR TITLE
Fix docblock indentation loss when fixing empty enclosing line

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/EmptyEnclosingLineSniff.php
@@ -91,7 +91,9 @@ class EmptyEnclosingLineSniff extends AbstractSniff
                 if ($contentLine < $braceLine + 1) {
                     $phpcsFile->fixer->addNewline($curlyBraceStartIndex);
                 } else {
-                    for ($i = $curlyBraceStartIndex + 1; $i < $beginningOfLine - 1; $i++) {
+                    // Replace first token with newline, remove the rest
+                    $phpcsFile->fixer->replaceToken($curlyBraceStartIndex + 1, $phpcsFile->eolChar);
+                    for ($i = $curlyBraceStartIndex + 2; $i < $beginningOfLine; $i++) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
                 }

--- a/tests/PhpCollective/Sniffs/WhiteSpace/EmptyEnclosingLineSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/EmptyEnclosingLineSniffTest.php
@@ -27,4 +27,31 @@ class EmptyEnclosingLineSniffTest extends TestCase
     {
         $this->assertSnifferCanFixErrors(new EmptyEnclosingLineSniff());
     }
+
+    /**
+     * Tests that tabs are preserved when fixing empty enclosing line.
+     *
+     * @return void
+     */
+    public function testTabsPreservedSniffer(): void
+    {
+        $this->prefix = 'tabs-';
+        $this->assertSnifferFindsErrors(new EmptyEnclosingLineSniff(), 1);
+        $this->prefix = null;
+    }
+
+    /**
+     * Tests fixer preserves indentation with tabs.
+     *
+     * This test verifies the fix for the bug where indentation was lost
+     * when removing empty lines after opening braces.
+     *
+     * @return void
+     */
+    public function testTabsPreservedFixer(): void
+    {
+        $this->prefix = 'tabs-';
+        $this->assertSnifferCanFixErrors(new EmptyEnclosingLineSniff());
+        $this->prefix = null;
+    }
 }

--- a/tests/_data/EmptyEnclosingLine/tabs-after.php
+++ b/tests/_data/EmptyEnclosingLine/tabs-after.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class TabsTest {
+	/**
+	 * @param string $foo The foo.
+	 *
+	 * @return void
+	 */
+	public function one(string $foo): void
+	{
+		echo $foo;
+	}
+}

--- a/tests/_data/EmptyEnclosingLine/tabs-before.php
+++ b/tests/_data/EmptyEnclosingLine/tabs-before.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class TabsTest {
+
+	/**
+	 * @param string $foo The foo.
+	 *
+	 * @return void
+	 */
+	public function one(string $foo): void
+	{
+		echo $foo;
+	}
+}


### PR DESCRIPTION
## Summary

- Fixed a bug where `EmptyEnclosingLineSniff` caused docblock indentation to be lost when combined with other fixers

## Problem

When processing a file with tabs and an empty line after a class opening brace, running phpcbf with the full PhpCollective ruleset caused the first content (typically a docblock) to lose its indentation entirely.

**Input:**
```php
class Example {

	/**
	 * @param string $foo
	 */
	public function test(string $foo): void {
```

**Before fix (incorrect):**
```php
class Example
{
/**
 * @param string $foo
 */
    public function test(string $foo): void
```

**After fix (correct):**
```php
class Example
{
    /**
     * @param string $foo
     */
    public function test(string $foo): void
```

## Root Cause

The `EmptyEnclosingLineSniff` removed all tokens between the opening brace and the first content line, including the newline that should remain. When combined with `Generic.WhiteSpace.DisallowTabIndent` (which converts tabs to spaces), the fixer loop interactions caused the indentation token to be lost.

## Solution

The fix explicitly preserves one newline after the opening brace by:
1. Replacing the first token after the brace with a newline character
2. Removing the remaining tokens up to (but not including) the indentation of the content line

All existing tests pass.