### PR TITLE
Add additional Universal sniffs to ruleset

### DIFF
--- a/PhpCollective/ruleset.xml
+++ b/PhpCollective/ruleset.xml
@@ -252,7 +252,12 @@
     <rule ref="Universal.Constants.UppercaseMagicConstants"/>
     <rule ref="Universal.WhiteSpace.PrecisionAlignment"/>
     <rule ref="Universal.Operators.ConcatPosition"/>
+    <rule ref="Universal.Operators.TypeSeparatorSpacing"/>
     <rule ref="Universal.UseStatements.NoUselessAliases"/>
+    <rule ref="Universal.CodeAnalysis.NoEchoSprintf"/>
+    <rule ref="Universal.CodeAnalysis.ConstructorDestructorReturn"/>
+    <rule ref="Universal.CodeAnalysis.ForeachUniqueAssignment"/>
+    <rule ref="Universal.CodeAnalysis.StaticInFinalClass"/>
     <rule ref="Modernize.FunctionCalls.Dirname"/>
     <rule ref="NormalizedArrays.Arrays.ArrayBraceSpacing"/>
 

--- a/docs/sniffs.md
+++ b/docs/sniffs.md
@@ -1,7 +1,7 @@
 # PhpCollective Code Sniffer
 
 
-The PhpCollectiveStrict standard contains 240 sniffs
+The PhpCollectiveStrict standard contains 245 sniffs
 
 Generic (27 sniffs)
 -------------------
@@ -270,11 +270,16 @@ Squiz (27 sniffs)
 - Squiz.WhiteSpace.SemicolonSpacing
 - Squiz.WhiteSpace.SuperfluousWhitespace
 
-Universal (5 sniffs)
---------------------
+Universal (10 sniffs)
+---------------------
+- Universal.CodeAnalysis.ConstructorDestructorReturn
+- Universal.CodeAnalysis.ForeachUniqueAssignment
+- Universal.CodeAnalysis.NoEchoSprintf
+- Universal.CodeAnalysis.StaticInFinalClass
 - Universal.Constants.LowercaseClassResolutionKeyword
 - Universal.Constants.UppercaseMagicConstants
 - Universal.Operators.ConcatPosition
+- Universal.Operators.TypeSeparatorSpacing
 - Universal.UseStatements.NoUselessAliases
 - Universal.WhiteSpace.PrecisionAlignment
 


### PR DESCRIPTION
## Summary

Adopts five PHPCSExtra Universal sniffs that are not yet covered by our ruleset (nor by any existing Slevomat/Generic/PSR rule we currently reference):

- `Universal.CodeAnalysis.NoEchoSprintf` — recommends \`printf()\` over \`echo sprintf()\`
- `Universal.CodeAnalysis.ConstructorDestructorReturn` — disallows return types / discourages return values in constructors/destructors
- `Universal.CodeAnalysis.ForeachUniqueAssignment` — detects foreach loops using identical variables for key and value
- `Universal.CodeAnalysis.StaticInFinalClass` — flags unnecessary \`static\` in final classes
- \`Universal.Operators.TypeSeparatorSpacing\` — spacing around \`|\` / \`&\` in union/intersection types

Related to #53.

\`composer cs-check\`, \`composer test\`, and \`composer stan\` all pass locally.