### PR TITLE
Add Universal attribute and whitespace sniffs

### DIFF
--- a/PhpCollective/ruleset.xml
+++ b/PhpCollective/ruleset.xml
@@ -252,6 +252,12 @@
     <rule ref="Universal.Constants.UppercaseMagicConstants"/>
     <rule ref="Universal.WhiteSpace.PrecisionAlignment"/>
     <rule ref="Universal.WhiteSpace.CommaSpacing"/>
+    <rule ref="Universal.WhiteSpace.AnonClassKeywordSpacing"/>
+    <rule ref="Universal.WhiteSpace.FirstClassCallableSpacing"/>
+    <rule ref="Universal.WhiteSpace.DisallowInlineTabs"/>
+    <rule ref="Universal.Attributes.BracketSpacing"/>
+    <rule ref="Universal.Attributes.DisallowAttributeParentheses"/>
+    <rule ref="Universal.Attributes.TrailingComma"/>
     <rule ref="Universal.ControlStructures.DisallowAlternativeSyntax"/>
     <rule ref="Universal.Operators.ConcatPosition"/>
     <rule ref="Universal.Operators.TypeSeparatorSpacing"/>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "phpcsstandards/phpcsextra": "^1.4.1",
+        "phpcsstandards/phpcsextra": "^1.5.0",
         "slevomat/coding-standard": "^8.23.0",
         "squizlabs/php_codesniffer": "^4.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=8.1",
         "phpcsstandards/phpcsextra": "^1.5.0",
         "slevomat/coding-standard": "^8.23.0",
-        "squizlabs/php_codesniffer": "^4.0.0"
+        "squizlabs/php_codesniffer": "^4.0.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0.0",

--- a/docs/sniffs.md
+++ b/docs/sniffs.md
@@ -1,7 +1,7 @@
 # PhpCollective Code Sniffer
 
 
-The PhpCollectiveStrict standard contains 245 sniffs
+The PhpCollectiveStrict standard contains 251 sniffs
 
 Generic (27 sniffs)
 -------------------
@@ -268,8 +268,11 @@ Squiz (27 sniffs)
 - Squiz.WhiteSpace.SemicolonSpacing
 - Squiz.WhiteSpace.SuperfluousWhitespace
 
-Universal (12 sniffs)
+Universal (18 sniffs)
 ---------------------
+- Universal.Attributes.BracketSpacing
+- Universal.Attributes.DisallowAttributeParentheses
+- Universal.Attributes.TrailingComma
 - Universal.CodeAnalysis.ConstructorDestructorReturn
 - Universal.CodeAnalysis.ForeachUniqueAssignment
 - Universal.CodeAnalysis.NoEchoSprintf
@@ -280,7 +283,10 @@ Universal (12 sniffs)
 - Universal.Operators.ConcatPosition
 - Universal.Operators.TypeSeparatorSpacing
 - Universal.UseStatements.NoUselessAliases
+- Universal.WhiteSpace.AnonClassKeywordSpacing
 - Universal.WhiteSpace.CommaSpacing
+- Universal.WhiteSpace.DisallowInlineTabs
+- Universal.WhiteSpace.FirstClassCallableSpacing
 - Universal.WhiteSpace.PrecisionAlignment
 
 Zend (1 sniff)


### PR DESCRIPTION
## Summary

Covers gaps in the current ruleset for PHP 8 attributes and whitespace — none of these are covered by existing Slevomat/Generic/PSR rules.

### Attributes
- \`Universal.Attributes.BracketSpacing\` — spacing inside \`#[…]\`
- \`Universal.Attributes.DisallowAttributeParentheses\` — drop \`()\` from param-less attributes (\`#[Foo]\` not \`#[Foo()]\`)
- \`Universal.Attributes.TrailingComma\` — trailing comma rules for multi-line attributes

### Whitespace
- \`Universal.WhiteSpace.AnonClassKeywordSpacing\` — spacing after \`class\` in \`new class (…) extends …\`
- \`Universal.WhiteSpace.FirstClassCallableSpacing\` — spacing in \`strlen(...)\` first-class-callable syntax
- \`Universal.WhiteSpace.DisallowInlineTabs\` — forbids tabs mid-line (complements existing \`Generic.WhiteSpace.DisallowTabIndent\` which only covers indent)

Related to #53.

\`composer cs-check\`, \`composer test\`, \`composer stan\` and \`composer docs\` all pass locally.