### PR TITLE
Disallow partial uses in ReferenceUsedNamesOnly

### DIFF
--- a/PhpCollective/ruleset.xml
+++ b/PhpCollective/ruleset.xml
@@ -28,6 +28,7 @@
         <properties>
             <property name="allowFallbackGlobalFunctions" value="true"/>
             <property name="allowFallbackGlobalConstants" value="true"/>
+            <property name="allowPartialUses" value="false"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
Partial namespace references like `Mockery\MockInterface` (as opposed to FQCN `\Mockery\MockInterface`) were not flagged by `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` because Slevomat's `allowPartialUses` property defaults to `true`. Setting it to `false` makes the sniff flag such references so they must be imported via a `use` statement.

Related: cakephp/cakephp-codesniffer#430 — same bug confirmed in this ruleset.

## Before

```php
namespace App\Test;

class FooTest {
    public function bar(Mockery\MockInterface $x): void {}  // not flagged
}
```

## After

```
ERROR | Partial use statements are not allowed, but referencing Mockery\MockInterface found.
```

The FQCN form (`\Mockery\MockInterface`) was and remains flagged by the same sniff via `ReferenceViaFullyQualifiedName`.

Note: this is a behavior-tightening change. Downstream code that intentionally uses partial imports (e.g. `use Doctrine\ORM\Mapping as ORM;` + `ORM\Entity`) will now error.