### PR TITLE
Fix DocBlockParamAllowDefaultValueSniff positional mismatch on partial @param lists

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockParamAllowDefaultValueSniff.php
@@ -56,7 +56,15 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSniff
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
-        $paramCount = 0;
+        // Index signature entries by parameter name so partial or out-of-order
+        // @param lists don't cause positional mismatches, which previously
+        // produced false-positive "missing type" fixes that fought
+        // DocBlockParamTypeMismatchSniff in an infinite fixer loop.
+        $signatureByName = [];
+        foreach ($methodSignature as $sigEntry) {
+            $signatureByName[$sigEntry['variable']] = $sigEntry;
+        }
+
         for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
@@ -64,12 +72,6 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSniff
             if ($tokens[$i]['content'] !== '@param') {
                 continue;
             }
-
-            if (empty($methodSignature[$paramCount])) {
-                continue;
-            }
-            $methodSignatureValue = $methodSignature[$paramCount];
-            $paramCount++;
 
             $classNameIndex = $i + 2;
 
@@ -83,15 +85,21 @@ class DocBlockParamAllowDefaultValueSniff extends AbstractSniff
                 continue;
             }
 
-            if (empty($methodSignatureValue['typehint']) && empty($methodSignatureValue['default'])) {
-                continue;
-            }
-
             /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode $valueNode */
             $valueNode = static::getValueNode($tokens[$i]['content'], $content);
             if ($valueNode instanceof InvalidTagValueNode || $valueNode instanceof TypelessParamTagValueNode) {
                 return;
             }
+
+            if (!isset($signatureByName[$valueNode->parameterName])) {
+                continue;
+            }
+            $methodSignatureValue = $signatureByName[$valueNode->parameterName];
+
+            if (empty($methodSignatureValue['typehint']) && empty($methodSignatureValue['default'])) {
+                continue;
+            }
+
             $parts = $this->valueNodeParts($valueNode);
 
             // We skip for mixed

--- a/tests/_data/DocBlockParamAllowDefaultValue/after.php
+++ b/tests/_data/DocBlockParamAllowDefaultValue/after.php
@@ -85,4 +85,18 @@ class FixMe
     public function arrayShape(array $array = null): void
     {
     }
+
+    /**
+     * Partial doc block - only $row and $errors are documented, skipping intermediate
+     * parameters. Positional matching would wrongly map docblock's $errors to the $accountId
+     * signature slot and try to add `int` to the list<string> type, fighting
+     * DocBlockParamTypeMismatchSniff in an infinite fixer loop. Must be matched by name.
+     *
+     * @param array<string, string> $row
+     * @param list<string> $errors
+     * @return void
+     */
+    public function partialDocBlock(array $row, int $accountId, array &$errors): void
+    {
+    }
 }

--- a/tests/_data/DocBlockParamAllowDefaultValue/before.php
+++ b/tests/_data/DocBlockParamAllowDefaultValue/before.php
@@ -85,4 +85,18 @@ class FixMe
     public function arrayShape(array $array = null): void
     {
     }
+
+    /**
+     * Partial doc block - only $row and $errors are documented, skipping intermediate
+     * parameters. Positional matching would wrongly map docblock's $errors to the $accountId
+     * signature slot and try to add `int` to the list<string> type, fighting
+     * DocBlockParamTypeMismatchSniff in an infinite fixer loop. Must be matched by name.
+     *
+     * @param array<string, string> $row
+     * @param list<string> $errors
+     * @return void
+     */
+    public function partialDocBlock(array $row, int $accountId, array &$errors): void
+    {
+    }
 }


### PR DESCRIPTION
## Summary

`DocBlockParamAllowDefaultValueSniff` matched docblock `@param` tags against the method signature by **position** (`\$methodSignature[\$paramCount++]`). When a docblock's `@param` list omitted intermediate parameters, positional indexing misaligned the comparison and the sniff produced false-positive \"missing type\" fixes.

### Reproduction

~~~ php
/**
 * @param array<string, string> \$row
 * @param list<string> \$errors
 */
private function buildUnit(
    array \$row,
    int \$accountId,
    Property \$property,
    array &\$errors,
): EntityInterface {
}
~~~

- Docblock has 2 `@param` tags: `\$row`, `\$errors`.
- Signature has 4 params: `\$row`, `\$accountId`, `\$property`, `\$errors`.
- Iterating docblock tag `\$errors` (count=1) mapped to signature slot 1, which is `int \$accountId`.
- Sniff concluded `\$errors` was \"missing type `int`\" and rewrote `list<string> \$errors` → `list<string>|int \$errors`.
- `DocBlockParamTypeMismatchSniff` (which correctly matches by name) then removed the bogus `|int`.
- The two sniffs fought pass after pass until phpcbf bailed with `FAILED TO FIX`.

### Fix

Build a `\$signatureByName` map keyed on the parameter variable name, parse each `@param`'s `\$valueNode` first, then look up the matching signature entry by `\$valueNode->parameterName`. Partial or out-of-order docblocks now skip params they don't mention instead of misaligning them against the wrong signature slot.

### Test

Added a regression fixture (`partialDocBlock` method in `tests/_data/DocBlockParamAllowDefaultValue/before.php` and `after.php`) that reproduces the infinite fixer loop on master and passes on this branch. Verified by stashing the sniff change and rerunning the test — it fails with the exact bad rewrite (`list<string>|int \$errors`).

Full suite (91 tests) still green.