### PR TITLE
Extend DocBlockTagOrder to class/interface/trait docblocks

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -189,13 +189,12 @@ class DocBlockTagOrderSniff extends AbstractSniff
             $index++;
         }
 
-        // Jump to the previous line
-        $currentLine = $tokens[$index]['line'];
-        while ($tokens[$index]['line'] === $currentLine) {
+        // Walk back to the line that actually contains this tag's content,
+        // skipping over any blank " * " separator lines so they are not folded
+        // into this tag's range and re-emitted in the rebuilt docblock.
+        while ($index > $startIndex && $tokens[$index]['code'] !== T_DOC_COMMENT_STRING && $tokens[$index]['code'] !== T_DOC_COMMENT_TAG) {
             $index--;
         }
-        // Fix for single line doc blocks
-        $index = max($index, $startIndex);
 
         return $this->getLastTokenOfLine($tokens, $index);
     }

--- a/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniff.php
@@ -13,7 +13,7 @@ use PhpCollective\Sniffs\AbstractSniffs\AbstractSniff;
 use PhpCollective\Traits\CommentingTrait;
 
 /**
- * Method doc blocks should have a consistent order of tag types.
+ * Function/method and class/interface/trait doc blocks should have a consistent order of tag types.
  *
  * @author Mark Scherer
  * @license MIT
@@ -23,11 +23,23 @@ class DocBlockTagOrderSniff extends AbstractSniff
     use CommentingTrait;
 
     /**
-     * All other tags will go above those
+     * Tag order for function/method docblocks. All other tags will go above those.
+     *
+     * Configurable via XML:
+     *
+     * ``` xml
+     * <rule ref="PhpCollective.Commenting.DocBlockTagOrder">
+     *     <properties>
+     *         <property name="order" type="array" value="deprecated,see,param,throws,return"/>
+     *     </properties>
+     * </rule>
+     * ```
+     *
+     * Note: leading "at" sign on tag names is optional; it will be normalized.
      *
      * @var array<int, string>
      */
-    protected array $order = [
+    public array $order = [
         '@deprecated',
         '@see',
         '@param',
@@ -36,11 +48,29 @@ class DocBlockTagOrderSniff extends AbstractSniff
     ];
 
     /**
+     * Tag order for class/interface/trait docblocks. All other tags will go above those.
+     *
+     * Configurable via XML the same way as `$order`.
+     *
+     * @var array<int, string>
+     */
+    public array $classOrder = [
+        '@template',
+        '@extends',
+        '@implements',
+        '@property',
+        '@property-read',
+        '@property-write',
+        '@method',
+        '@mixin',
+    ];
+
+    /**
      * @inheritDoc
      */
     public function register(): array
     {
-        return [T_FUNCTION];
+        return [T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT];
     }
 
     /**
@@ -49,11 +79,14 @@ class DocBlockTagOrderSniff extends AbstractSniff
     public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
+        $isFunction = $tokens[$stackPtr]['code'] === T_FUNCTION;
 
-        // Don't mess with closures
-        $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
-        if (!$this->isGivenKind(Tokens::$methodPrefixes, $tokens[$prevIndex])) {
-            return;
+        if ($isFunction) {
+            // Don't mess with closures
+            $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+            if (!$this->isGivenKind(Tokens::$methodPrefixes, $tokens[$prevIndex])) {
+                return;
+            }
         }
 
         $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $stackPtr);
@@ -63,20 +96,23 @@ class DocBlockTagOrderSniff extends AbstractSniff
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
-        $tags = $this->readTags($phpcsFile, $docBlockStartIndex, $docBlockEndIndex);
-        $tags = $this->checkAnnotationTagOrder($tags);
+        $order = $isFunction ? $this->order : $this->classOrder;
 
-        $this->fixOrder($phpcsFile, $docBlockStartIndex, $docBlockEndIndex, $tags);
+        $tags = $this->readTags($phpcsFile, $docBlockStartIndex, $docBlockEndIndex);
+        $tags = $this->checkAnnotationTagOrder($tags, $order);
+
+        $this->fixOrder($phpcsFile, $docBlockStartIndex, $docBlockEndIndex, $tags, $order);
     }
 
     /**
      * @param array<int, array<string, mixed>> $tags
+     * @param array<int, string> $orderList
      *
      * @return array<int, array<string, mixed>>
      */
-    protected function checkAnnotationTagOrder(array $tags): array
+    protected function checkAnnotationTagOrder(array $tags, array $orderList): array
     {
-        $order = $this->getTagOrderMap();
+        $order = $this->getTagOrderMap($orderList);
 
         $currentOrder = null;
         foreach ($tags as $i => $tag) {
@@ -206,10 +242,11 @@ class DocBlockTagOrderSniff extends AbstractSniff
      * @param int $docBlockStartIndex
      * @param int $docBlockEndIndex
      * @param array<int, array<string, mixed>> $tags
+     * @param array<int, string> $orderList
      *
      * @return void
      */
-    protected function fixOrder(File $phpcsFile, int $docBlockStartIndex, int $docBlockEndIndex, array $tags): void
+    protected function fixOrder(File $phpcsFile, int $docBlockStartIndex, int $docBlockEndIndex, array $tags, array $orderList): void
     {
         $errors = [];
         foreach ($tags as $i => $tag) {
@@ -231,7 +268,7 @@ class DocBlockTagOrderSniff extends AbstractSniff
 
         $phpcsFile->fixer->beginChangeset();
 
-        $order = $this->getTagOrderMap();
+        $order = $this->getTagOrderMap($orderList);
 
         $newOrder = [];
         foreach ($tags as $tag) {
@@ -262,10 +299,17 @@ class DocBlockTagOrderSniff extends AbstractSniff
     }
 
     /**
+     * @param array<int, string> $orderList
+     *
      * @return array<string, int>
      */
-    protected function getTagOrderMap(): array
+    protected function getTagOrderMap(array $orderList): array
     {
-        return array_flip($this->order);
+        $normalized = [];
+        foreach ($orderList as $tag) {
+            $normalized[] = str_starts_with($tag, '@') ? $tag : '@' . $tag;
+        }
+
+        return array_flip($normalized);
     }
 }

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniffTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Commenting;
+
+use PhpCollective\Sniffs\Commenting\DocBlockTagOrderSniff;
+use PhpCollective\Test\TestCase;
+
+class DocBlockTagOrderSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testDocBlockTagOrderSniffer(): void
+    {
+        $sniff = new DocBlockTagOrderSniff();
+        // One error per misordered docblock: class-level + function-level.
+        $this->assertSnifferFindsFixableErrors($sniff, 2, 2);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocBlockTagOrderFixer(): void
+    {
+        $sniff = new DocBlockTagOrderSniff();
+        $this->assertSnifferCanFixErrors($sniff, 2);
+    }
+
+    /**
+     * Custom $classOrder set via property override (mirrors XML configuration).
+     *
+     * @return void
+     */
+    public function testDocBlockTagOrderCustomClassOrder(): void
+    {
+        $this->prefix = 'custom-order.';
+
+        $sniff = new DocBlockTagOrderSniff();
+        $sniff->classOrder = ['@mixin', '@method', '@property', '@extends'];
+
+        $this->assertSnifferCanFixErrors($sniff, 1);
+
+        $this->prefix = null;
+    }
+
+    /**
+     * Tag names without leading "@" should be normalized.
+     *
+     * @return void
+     */
+    public function testDocBlockTagOrderCustomClassOrderWithoutAtPrefix(): void
+    {
+        $this->prefix = 'custom-order.';
+
+        $sniff = new DocBlockTagOrderSniff();
+        $sniff->classOrder = ['mixin', 'method', 'property', 'extends'];
+
+        $this->assertSnifferCanFixErrors($sniff, 1);
+
+        $this->prefix = null;
+    }
+}

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockTagOrderSniffTest.php
@@ -64,4 +64,21 @@ class DocBlockTagOrderSniffTest extends TestCase
 
         $this->prefix = null;
     }
+
+    /**
+     * Blank-line separators between tag groups should be normalized away when tags are reordered,
+     * otherwise an orphan blank line may end up splitting a now-coherent same-kind tag group.
+     *
+     * @return void
+     */
+    public function testDocBlockTagOrderNormalizesBlankLineSeparators(): void
+    {
+        $this->prefix = 'blank-lines.';
+
+        $sniff = new DocBlockTagOrderSniff();
+
+        $this->assertSnifferCanFixErrors($sniff, 1);
+
+        $this->prefix = null;
+    }
 }

--- a/tests/_data/DocBlockTagOrder/after.php
+++ b/tests/_data/DocBlockTagOrder/after.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * Class-level docblock with scrambled tag groups.
+ *
+ * @author Some Author
+ * @extends \BaseTable<array{Slugged: \Behavior, Tree: \Behavior}>
+ * @property \Foo $Boards
+ * @property \Foo $LastUsers
+ * @method \Foo save(\Bar $entity, array $options = [])
+ * @method \Foo get(mixed $primaryKey, array $finder = 'all')
+ * @mixin \BehaviorOne
+ * @mixin \BehaviorTwo
+ */
+class FixMe
+{
+    /**
+     * @param string $foo
+     * @throws \RuntimeException
+     * @return string
+     */
+    public function badOrder(string $foo): string
+    {
+        return $foo;
+    }
+}

--- a/tests/_data/DocBlockTagOrder/before.php
+++ b/tests/_data/DocBlockTagOrder/before.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * Class-level docblock with scrambled tag groups.
+ *
+ * @author Some Author
+ * @method \Foo save(\Bar $entity, array $options = [])
+ * @property \Foo $Boards
+ * @mixin \BehaviorOne
+ * @extends \BaseTable<array{Slugged: \Behavior, Tree: \Behavior}>
+ * @method \Foo get(mixed $primaryKey, array $finder = 'all')
+ * @property \Foo $LastUsers
+ * @mixin \BehaviorTwo
+ */
+class FixMe
+{
+    /**
+     * @return string
+     * @param string $foo
+     * @throws \RuntimeException
+     */
+    public function badOrder(string $foo): string
+    {
+        return $foo;
+    }
+}

--- a/tests/_data/DocBlockTagOrder/blank-lines.after.php
+++ b/tests/_data/DocBlockTagOrder/blank-lines.after.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * Class with blank-line separators between tag groups.
+ *
+ * @extends \BaseTable
+ * @property \Foo $LastUsers
+ * @method \Foo first()
+ * @method \Foo second()
+ * @method \Foo third()
+ * @mixin \Bar
+ */
+class FixMe
+{
+}

--- a/tests/_data/DocBlockTagOrder/blank-lines.before.php
+++ b/tests/_data/DocBlockTagOrder/blank-lines.before.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * Class with blank-line separators between tag groups.
+ *
+ * @method \Foo first()
+ *
+ * @mixin \Bar
+ *
+ * @property \Foo $LastUsers
+ * @method \Foo second()
+ * @extends \BaseTable
+ * @method \Foo third()
+ */
+class FixMe
+{
+}

--- a/tests/_data/DocBlockTagOrder/custom-order.after.php
+++ b/tests/_data/DocBlockTagOrder/custom-order.after.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * @mixin \Behavior
+ * @method \Foo bar()
+ * @property \Foo $X
+ * @extends \BaseTable
+ */
+class FixMe
+{
+}

--- a/tests/_data/DocBlockTagOrder/custom-order.before.php
+++ b/tests/_data/DocBlockTagOrder/custom-order.before.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+/**
+ * @extends \BaseTable
+ * @property \Foo $X
+ * @method \Foo bar()
+ * @mixin \Behavior
+ */
+class FixMe
+{
+}


### PR DESCRIPTION
## Summary

Currently `DocBlockTagOrder` only enforces tag ordering on function/method docblocks. Class-level docblocks — typical example, a CakePHP table where association property tags, ORM method tags, behavior mixin tags, and a generic extends tag accumulate over time as IDE-helpers append output — go unsorted.

This PR extends the sniff to also register on `T_CLASS`, `T_INTERFACE`, `T_TRAIT` and adds a separate `classOrder` property so the class-level order is independent of the function-level one.

### Default class order

```
template, extends, implements, property, property-read, property-write, method, mixin
```

Reasoning:

- `template` / `extends` / `implements` first — these declare the class's own type signature (PHPStan/Psalm convention).
- `property` next — describes class-level state.
- `method` — describes magic / dynamically-generated members.
- `mixin` last — additive/late-bound, the class is fully described by the time you read these.

Tags not in the list keep the existing "float to top" behavior.

### XML configurability

Both `order` (function-level, was `protected`, now `public`) and `classOrder` (new) can be overridden:

```xml
<rule ref="PhpCollective.Commenting.DocBlockTagOrder">
    <properties>
        <property name="classOrder" type="array" value="extends,property,method,mixin"/>
    </properties>
</rule>
```

Leading `@` on tag names is optional and gets normalized.

## Tests

- `DocBlockTagOrderSniffTest` is new — there were no existing tests for this sniff. Covers both function-level (regression) and class-level (new) cases plus two configurability variants.
- All 95 existing sniffer tests still pass; phpstan and phpcs clean.