### PR TITLE
Perf: cache class-name resolution and skip redundant return-type body scans

### DIFF
--- a/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
+++ b/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
@@ -29,6 +29,27 @@ abstract class AbstractSniff implements Sniff
     ];
 
     /**
+     * Per-file cache for class-name-with-namespace resolution.
+     *
+     * `getClassNameWithNamespace()` walks the token stream backwards from
+     * the end of the file to find the class/trait/interface/enum keyword.
+     * The result is stable for the lifetime of a phpcs run on a given file,
+     * but the original implementation re-computed it on every sniff call.
+     * Caching by filename turns dozens-to-hundreds of full-file walks per
+     * large file into a single walk.
+     *
+     * @var array<string, string|null>
+     */
+    private static array $classNameWithNamespaceCache = [];
+
+    /**
+     * Per-file cache for class name resolution (with filename fallback).
+     *
+     * @var array<string, string>
+     */
+    private static array $classNameCache = [];
+
+    /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      *
@@ -98,22 +119,27 @@ abstract class AbstractSniff implements Sniff
      */
     protected function getClassNameWithNamespace(File $phpcsFile): ?string
     {
+        $cacheKey = $phpcsFile->getFilename();
+        if (array_key_exists($cacheKey, self::$classNameWithNamespaceCache)) {
+            return self::$classNameWithNamespaceCache[$cacheKey];
+        }
+
         try {
             $lastToken = TokenHelper::getLastTokenPointer($phpcsFile);
         } catch (EmptyFileException $e) {
-            return null;
+            return self::$classNameWithNamespaceCache[$cacheKey] = null;
         }
 
         if (!NamespaceHelper::findCurrentNamespaceName($phpcsFile, $lastToken)) {
-            return null;
+            return self::$classNameWithNamespaceCache[$cacheKey] = null;
         }
 
         $prevIndex = $phpcsFile->findPrevious([T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM], $lastToken);
         if (!$prevIndex) {
-            return null;
+            return self::$classNameWithNamespaceCache[$cacheKey] = null;
         }
 
-        return ClassHelper::getFullyQualifiedName(
+        return self::$classNameWithNamespaceCache[$cacheKey] = ClassHelper::getFullyQualifiedName(
             $phpcsFile,
             $prevIndex,
         );
@@ -126,10 +152,15 @@ abstract class AbstractSniff implements Sniff
      */
     protected function getClassName(File $phpcsFile): string
     {
+        $cacheKey = $phpcsFile->getFilename();
+        if (isset(self::$classNameCache[$cacheKey])) {
+            return self::$classNameCache[$cacheKey];
+        }
+
         $namespace = $this->getClassNameWithNamespace($phpcsFile);
 
         if ($namespace) {
-            return trim($namespace, '\\');
+            return self::$classNameCache[$cacheKey] = trim($namespace, '\\');
         }
 
         $fileName = $phpcsFile->getFilename();
@@ -143,7 +174,7 @@ abstract class AbstractSniff implements Sniff
         $className = implode('\\', $classNameParts);
         $className = str_replace('.php', '', $className);
 
-        return $className;
+        return self::$classNameCache[$cacheKey] = $className;
     }
 
     /**

--- a/PhpCollective/Sniffs/Commenting/DocBlockReturnSelfSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockReturnSelfSniff.php
@@ -43,6 +43,8 @@ class DocBlockReturnSelfSniff extends AbstractSniff
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
+        $ownClassName = null;
+
         for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
             if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
                 continue;
@@ -75,6 +77,28 @@ class DocBlockReturnSelfSniff extends AbstractSniff
             }
 
             $parts = explode('|', $content);
+
+            // The three assertions below all act only when `parts` contains
+            // `self`, `$this`, or the own (fully qualified) class name.
+            // Skipping the expensive return-type body scan when none of these
+            // are present turns this sniff from O(methods * body_size) into
+            // ~O(methods) for files where most @return tags are plain types
+            // like `void`, `int`, `array<...>`, etc.
+            if ($ownClassName === null) {
+                $ownClassName = '\\' . $this->getClassName($phpcsFile);
+            }
+            $needsReturnTypeCheck = false;
+            foreach ($parts as $part) {
+                if ($part === 'self' || $part === '$this' || $part === $ownClassName) {
+                    $needsReturnTypeCheck = true;
+
+                    break;
+                }
+            }
+            if (!$needsReturnTypeCheck) {
+                continue;
+            }
+
             $returnTypes = $this->getReturnTypes($phpcsFile, $stackPointer);
 
             $this->assertCorrectDocBlockParts($phpcsFile, $classNameIndex, $parts, $returnTypes, $appendix);


### PR DESCRIPTION
## Summary

Two small changes that cut whole-codebase `composer cs-check` time by ~30% and the slowest single file by ~50% on real-world large CakePHP code, with no behaviour change.

### 1. `AbstractSniff`: per-file cache for class-name resolution

`getClassNameWithNamespace()` calls `$phpcsFile->findPrevious([T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM], $lastToken)` — i.e. it scans backwards from the last token of the file to find the class declaration, which sits at the top. The result is stable for the lifetime of a phpcs run on a given file.

It is invoked indirectly by every sniff that needs the current class name, once per `T_FUNCTION`:

- `MethodTypeHintSniff::process` -> `getCurrentClassName()`
- `ReturnTypeHintSniff::assertNotThisOrStatic` -> `getClassNameWithNamespace()`
- `DocBlockReturnSelfSniff::fixClassToThis` -> `getClassName()`
- `FullyQualifiedClassNameInDocBlockSniff::findInSameNameSpace` -> `getNamespace()`
- `Psr4Sniff::process` -> `getClassName()`

On an 11k-line controller with ~100 methods, that is hundreds of full-file walks per file. Caching by filename turns this into one walk per file. Cache key is `$phpcsFile->getFilename()`; entries live for the lifetime of the worker process, which is bounded by the file set assigned to it.

### 2. `DocBlockReturnSelfSniff`: pre-filter before expensive return-type scan

`getReturnTypes()` walks the entire function body looking for return statements. The original `process()` called it unconditionally for every method with a return docblock entry. But the three assertions guarded by it only fire when the annotation contains `self`, `$this`, or the own class name — so for plain types like `void`, `int`, `string`, `array<...>`, all that work was wasted.

Added a cheap pre-filter on the `parts` array before the body scan. Skips the scan for the common case.

## Benchmarks

Measured on a 1095-file CakePHP 5 app whose biggest controller is `ResidentsController.php` at 11,111 lines / ~100 actions, on `squizlabs/php_codesniffer:^4.0.1` and `slevomat/coding-standard:^8.23.0`:

| Run | Before | After | Delta |
|---|---|---|---|
| `parallel=1`, ResidentsController.php alone | 40s | 20s | **-50%** |
| `parallel=16`, whole codebase (wall) | 2m08s | 1m30s | **-30%** |
| `parallel=16`, whole codebase (CPU) | 5m55s | 4m37s | **-22%** |

Top entries in the perf report on the slowest file went from:

- before: `PhpCollective.Commenting.DocBlockReturnSelf` 5.86s (32%), `PhpCollective.Classes.MethodTypeHint` 3.27s (18%)
- after: both dropped out of the top 22 entirely

The 50% gain on the biggest file is the key win — it eliminates the load-imbalance bottleneck that previously prevented `parallel=16` from scaling much beyond 2.7x.

## Verification

- Existing PHPUnit suite passes (100 tests / 122 assertions).
- `composer cs-check` and `composer stan` on this repo: clean.
- Output diff on a real 1095-file codebase: identical violations reported before vs after.
- Smoke test on a hand-crafted file exercising `self`, `$this`, and fully-qualified class name in return docblocks: identical 3 errors reported before vs after, with both fixable markers preserved.
