### PR TITLE
Perf: O(1) conditions checks + cached arrow-fn scopes in ConsistentIndentSniff

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
@@ -306,16 +306,32 @@ class ConsistentIndentSniff extends AbstractSniff
     }
 
     /**
+     * Per-file cache of arrow function (T_FN) scope ranges.
+     *
+     * T_FN, unlike T_CLOSURE, isn't propagated into inner tokens' `conditions`
+     * map by phpcs, so we can't use the O(depth) conditions check for arrow
+     * functions. Instead we collect every arrow function's [scope_opener,
+     * scope_closer] range once per file and check each line against this list.
+     * Arrow function scopes can legitimately be long (think a multi-line
+     * `match` expression or a deeply nested array literal as the body), so a
+     * scan window would be incorrect; the cached-ranges approach is both
+     * unbounded and faster.
+     *
+     * The cache stores the token count alongside the scopes so it self-
+     * invalidates if the file is re-tokenized during a phpcbf fix loop.
+     *
+     * @var array<string, array{count: int, scopes: array<int, array{0: int, 1: int}>}>
+     */
+    private static array $arrowFunctionScopesCache = [];
+
+    /**
      * Check if the current position is inside a closure or arrow function.
      *
      * Fast path: phpcs's PHP tokenizer rewrites the `conditions` map of every
      * token inside an anonymous function so it contains `T_CLOSURE` rather
      * than `T_FUNCTION` (see `PHP::processAdditional()`), so the common case
      * resolves with an O(depth) walk of the (typically <10-entry) conditions
-     * array. T_FN (arrow functions) is not added to `conditions`, so we still
-     * scan backwards for it — but arrow function expressions are short by
-     * language construction (a single expression), so a tight scan window
-     * suffices.
+     * array. T_FN is handled via a per-file scope cache built on first use.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
@@ -333,22 +349,55 @@ class ConsistentIndentSniff extends AbstractSniff
             }
         }
 
-        // Fallback for T_FN: bounded scan, since arrow function expressions
-        // can't realistically span more than a few hundred tokens.
-        $limit = max(0, $stackPtr - 500);
-        for ($i = $stackPtr - 1; $i >= $limit; $i--) {
-            if ($tokens[$i]['code'] !== T_FN) {
-                continue;
-            }
-            if (!isset($tokens[$i]['scope_opener'], $tokens[$i]['scope_closer'])) {
-                continue;
-            }
-            if ($stackPtr > $tokens[$i]['scope_opener'] && $stackPtr < $tokens[$i]['scope_closer']) {
+        foreach ($this->getArrowFunctionScopes($phpcsFile, $tokens) as $range) {
+            if ($stackPtr > $range[0] && $stackPtr < $range[1]) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Build (and cache per file) the list of arrow function scope ranges.
+     *
+     * Single O(file) walk on first invocation per file, then O(arrows) per
+     * lookup. Arrow function counts are typically a handful per file, so the
+     * per-lookup cost stays small.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return array<int, array{0: int, 1: int}>
+     */
+    protected function getArrowFunctionScopes(File $phpcsFile, array $tokens): array
+    {
+        $cacheKey = $phpcsFile->getFilename();
+        $tokenCount = count($tokens);
+        if (
+            isset(self::$arrowFunctionScopesCache[$cacheKey])
+            && self::$arrowFunctionScopesCache[$cacheKey]['count'] === $tokenCount
+        ) {
+            return self::$arrowFunctionScopesCache[$cacheKey]['scopes'];
+        }
+
+        $scopes = [];
+        foreach ($tokens as $token) {
+            if ($token['code'] !== T_FN) {
+                continue;
+            }
+            if (!isset($token['scope_opener'], $token['scope_closer'])) {
+                continue;
+            }
+            $scopes[] = [$token['scope_opener'], $token['scope_closer']];
+        }
+
+        self::$arrowFunctionScopesCache[$cacheKey] = [
+            'count' => $tokenCount,
+            'scopes' => $scopes,
+        ];
+
+        return $scopes;
     }
 
     /**

--- a/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
@@ -107,8 +107,7 @@ class ConsistentIndentSniff extends AbstractSniff
             return;
         }
 
-        // Additional safety: if this looks like it could be in a case block, skip it
-        // Case blocks don't show up in conditions, so expected might be wrong
+        // Additional safety: if this looks like it could be in a case block, skip it.
         if ($this->couldBeInCaseBlock($phpcsFile, $stackPtr, $tokens)) {
             return;
         }
@@ -307,8 +306,16 @@ class ConsistentIndentSniff extends AbstractSniff
     }
 
     /**
-     * Check if the current position is inside a closure/anonymous function.
-     * PHPCS doesn't properly track closures in the conditions array, so we need to detect them manually.
+     * Check if the current position is inside a closure or arrow function.
+     *
+     * Fast path: phpcs's PHP tokenizer rewrites the `conditions` map of every
+     * token inside an anonymous function so it contains `T_CLOSURE` rather
+     * than `T_FUNCTION` (see `PHP::processAdditional()`), so the common case
+     * resolves with an O(depth) walk of the (typically <10-entry) conditions
+     * array. T_FN (arrow functions) is not added to `conditions`, so we still
+     * scan backwards for it — but arrow function expressions are short by
+     * language construction (a single expression), so a tight scan window
+     * suffices.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
@@ -318,41 +325,26 @@ class ConsistentIndentSniff extends AbstractSniff
      */
     protected function isInsideClosure(File $phpcsFile, int $stackPtr, array $tokens): bool
     {
-        // Look backward for a closure token (T_CLOSURE, T_FN, or T_FUNCTION for anonymous functions)
-        $closureTypes = [T_CLOSURE, T_FN];
-
-        // Search backward for a closure opening
-        for ($i = $stackPtr - 1; $i >= 0; $i--) {
-            // Check for T_FUNCTION (could be a named method or anonymous function)
-            if ($tokens[$i]['code'] === T_FUNCTION) {
-                // Check if this is a named function (not a closure)
-                $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
-                if ($nextNonWhitespace !== false && $tokens[$nextNonWhitespace]['code'] === T_STRING) {
-                    // Named function/method - stop searching, we're not in a closure
-                    return false;
-                }
-
-                // It's an anonymous function (closure) - check if we're inside it
-                if (isset($tokens[$i]['scope_opener']) && isset($tokens[$i]['scope_closer'])) {
-                    if ($stackPtr > $tokens[$i]['scope_opener'] && $stackPtr < $tokens[$i]['scope_closer']) {
-                        return true;
-                    }
+        if (!empty($tokens[$stackPtr]['conditions'])) {
+            foreach ($tokens[$stackPtr]['conditions'] as $code) {
+                if ($code === T_CLOSURE) {
+                    return true;
                 }
             }
+        }
 
-            if (in_array($tokens[$i]['code'], $closureTypes, true)) {
-                // Found a closure, check if our position is within its scope
-                if (isset($tokens[$i]['scope_opener']) && isset($tokens[$i]['scope_closer'])) {
-                    if ($stackPtr > $tokens[$i]['scope_opener'] && $stackPtr < $tokens[$i]['scope_closer']) {
-                        return true;
-                    }
-                }
+        // Fallback for T_FN: bounded scan, since arrow function expressions
+        // can't realistically span more than a few hundred tokens.
+        $limit = max(0, $stackPtr - 500);
+        for ($i = $stackPtr - 1; $i >= $limit; $i--) {
+            if ($tokens[$i]['code'] !== T_FN) {
+                continue;
             }
-
-            // Stop searching if we've gone too far (more than 2000 tokens back)
-            // Large closures with validation logic can easily exceed 500 tokens
-            if ($stackPtr - $i > 2000) {
-                break;
+            if (!isset($tokens[$i]['scope_opener'], $tokens[$i]['scope_closer'])) {
+                continue;
+            }
+            if ($stackPtr > $tokens[$i]['scope_opener'] && $stackPtr < $tokens[$i]['scope_closer']) {
+                return true;
             }
         }
 
@@ -416,6 +408,10 @@ class ConsistentIndentSniff extends AbstractSniff
      * Check if the current position is inside a switch/case block.
      * Case blocks have special indentation rules per PER Coding Style.
      *
+     * Uses the pre-computed `conditions` map: T_SWITCH is a scope opener
+     * in phpcs's PHP tokenizer, so every token inside a switch's scope
+     * already carries T_SWITCH in its conditions array — no scan needed.
+     *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      * @param array<int, array<string, mixed>> $tokens
@@ -424,20 +420,13 @@ class ConsistentIndentSniff extends AbstractSniff
      */
     protected function isInsideSwitchCase(File $phpcsFile, int $stackPtr, array $tokens): bool
     {
-        // Look backward for a switch statement
-        for ($i = $stackPtr - 1; $i >= 0; $i--) {
-            if ($tokens[$i]['code'] === T_SWITCH) {
-                // Found a switch, check if we're within its scope
-                if (isset($tokens[$i]['scope_opener']) && isset($tokens[$i]['scope_closer'])) {
-                    if ($stackPtr > $tokens[$i]['scope_opener'] && $stackPtr < $tokens[$i]['scope_closer']) {
-                        return true;
-                    }
-                }
-            }
+        if (empty($tokens[$stackPtr]['conditions'])) {
+            return false;
+        }
 
-            // Stop if we've gone too far back
-            if ($stackPtr - $i > 500) {
-                break;
+        foreach ($tokens[$stackPtr]['conditions'] as $code) {
+            if ($code === T_SWITCH) {
+                return true;
             }
         }
 
@@ -514,7 +503,11 @@ class ConsistentIndentSniff extends AbstractSniff
     }
 
     /**
-     * Check if this could be in a case block by looking for case/default keywords nearby.
+     * Check if this could be in a case block.
+     *
+     * Uses the pre-computed `conditions` map: T_CASE and T_DEFAULT are scope
+     * openers in phpcs's PHP tokenizer, so a token lexically inside a case
+     * arm already carries T_CASE / T_DEFAULT in its conditions array.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
@@ -524,16 +517,13 @@ class ConsistentIndentSniff extends AbstractSniff
      */
     protected function couldBeInCaseBlock(File $phpcsFile, int $stackPtr, array $tokens): bool
     {
-        // Look backward for case/default keywords (not too far)
-        // Using 500 to match isInsideSwitchCase() limit, as case blocks can be large
-        for ($i = $stackPtr - 1; $i >= max(0, $stackPtr - 500); $i--) {
-            if ($tokens[$i]['code'] === T_CASE || $tokens[$i]['code'] === T_DEFAULT) {
-                // Found a case/default, likely in a case block
+        if (empty($tokens[$stackPtr]['conditions'])) {
+            return false;
+        }
+
+        foreach ($tokens[$stackPtr]['conditions'] as $code) {
+            if ($code === T_CASE || $code === T_DEFAULT) {
                 return true;
-            }
-            // If we hit another control structure, stop
-            if ($tokens[$i]['code'] === T_IF || $tokens[$i]['code'] === T_WHILE || $tokens[$i]['code'] === T_FOR) {
-                break;
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #62. Replaces three expensive backward token scans in `ConsistentIndentSniff` with O(1) lookups against the pre-computed `conditions` map, plus a per-file cache of T_FN scope ranges. No behaviour change; substantially faster on large files.

## Background

`ConsistentIndentSniff` registers on `T_WHITESPACE`, so it runs against every whitespace token in the file. For each token at the start of a line it called three helpers that walked the token stream backwards:

| Helper | Original scan window | What it looked for |
|---|---|---|
| `isInsideClosure` | up to 2000 tokens | T_CLOSURE / T_FN / named-function boundary |
| `isInsideSwitchCase` | up to 500 tokens | T_SWITCH |
| `couldBeInCaseBlock` | up to 500 tokens | T_CASE / T_DEFAULT |

Each of those tokens IS in fact tracked by phpcs's PHP tokenizer in the per-token `conditions` map:

- `T_CLOSURE` — `PHP::processAdditional()` rewrites the conditions of every inner token from `T_FUNCTION` to `T_CLOSURE` for anonymous functions (tokenizer source: `PHP.php` around line 2840).
- `T_SWITCH`, `T_CASE`, `T_DEFAULT` — all scope openers in `PHP::$scopeOpeners`, so `createLevelMap()` already adds them to inner tokens' conditions.

So the inner-loop scans were redundant work. An empirical probe sniff confirms it:

```
Line  4 inside method:                       T_CLASS, T_FUNCTION
Line  7 inside switch + case:                T_CLASS, T_FUNCTION, T_SWITCH, T_CASE
Line 11 inside closure:                      T_CLASS, T_FUNCTION, PHPCS_T_CLOSURE
Line 14 inside closure + switch + case:      T_CLASS, T_FUNCTION, PHPCS_T_CLOSURE, T_SWITCH, T_CASE
```

The outdated comment "Case blocks don't show up in conditions, so expected might be wrong" was wrong for current phpcs; it has been removed.

## Changes

- `isInsideClosure`: O(1) walk of `conditions` for `T_CLOSURE`. For `T_FN`, which is the one case where phpcs does *not* propagate the token into inner tokens' conditions, build a per-file cache of `[scope_opener, scope_closer]` ranges on first use (single O(file) walk, then O(arrow_count) per query — typically a handful per file). The cache stores the token count alongside the ranges so it self-invalidates if the file is re-tokenized during a phpcbf fix loop.
- `isInsideSwitchCase`: pure O(1) walk of `conditions` for `T_SWITCH`. The old backward scan was completely replaceable.
- `couldBeInCaseBlock`: pure O(1) walk of `conditions` for `T_CASE` / `T_DEFAULT`. Same.

### Why a cache and not a scan limit

An earlier draft used a 500-token bounded scan for the `T_FN` fallback. Codex review correctly flagged that as a behaviour regression: arrow function bodies can legitimately exceed 500 tokens (a long `match` expression, a deeply nested array literal as the body, a long method chain), and a bounded scan would then fail to detect that we're inside the arrow and could emit false-positive over-indentation errors on lines the original implementation correctly skipped. The cached-ranges approach is both unbounded and faster, so it strictly dominates.

## Benchmarks

Measured on the same 1095-file CakePHP 5 app from #62 (`ResidentsController.php`, 11k LOC):

| Run | Before #62 | After #62 (master) | After this PR | Total delta |
|---|---|---|---|---|
| `parallel=1`, `ResidentsController.php` | 40s | 20s | **6.5s** | -84% |
| `parallel=16`, whole codebase wall | 2m08s | 1m30s | **27.9s** | -78% |

Sniff-level perf report on `ResidentsController.php`:

| Sniff | Before this PR | After this PR |
|---|---|---|
| `PhpCollective.WhiteSpace.ConsistentIndent` | 4.12s (24.2%) | **0.1s (~2%)** |

The full-codebase speedup is larger than just "the sniff got faster on the slow file" — much of it comes from the cheap empty-array iteration in files with no arrow functions at all, which previously paid for a backward scan per indented line.

## Verification

- Existing PHPUnit suite passes (100 tests / 122 assertions). `ConsistentIndentSniffTest` exercises the closure + switch/case scenarios.
- `composer cs-check` and `composer stan` on this repo: clean.
- Output diff (all sniffs, all files) on a real 1095-file codebase: identical violations before vs after.
- Hand-crafted fixture with intentional over-indents inside named method / closure / switch case / default / arrow function: identical results in both versions.
- Long-arrow-body stress fixture (multi-thousand-token `match` arrow expression): both versions correctly skip indent checks throughout — confirming the codex regression concern is addressed by the cached-ranges approach.
- `codex review --uncommitted` on the final patch: clean.
