### PR TITLE
Perf: cache UseStatementsTrait getUseStatements + bound throw class-name lookup

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockThrowsSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockThrowsSniff.php
@@ -132,7 +132,14 @@ class DocBlockThrowsSniff extends AbstractSniff
                 $classIndex = $nextIndex;
             }
 
-            $doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $i + 1, $scopeCloser);
+            // Constrain the `::` lookup to the current statement.
+            // The original code searched up to $scopeCloser, which on long
+            // method bodies could pick up an unrelated `::` operator from
+            // a later statement (and silently used it to gate exception
+            // collection for *this* throw). Bound by the next `;`.
+            $statementEnd = $phpcsFile->findNext(T_SEMICOLON, $i + 1, $scopeCloser);
+            $doubleColonSearchEnd = $statementEnd !== false ? $statementEnd : $scopeCloser;
+            $doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $i + 1, $doubleColonSearchEnd);
 
             if (!$newIndex && !$classIndex && !$doubleColonIndex) {
                 continue;

--- a/PhpCollective/Traits/UseStatementsTrait.php
+++ b/PhpCollective/Traits/UseStatementsTrait.php
@@ -13,6 +13,32 @@ use PHP_CodeSniffer\Util\Tokens;
 trait UseStatementsTrait
 {
     /**
+     * Per-file cache of parsed `use` statements.
+     *
+     * `getUseStatements()` iterates every token in the file via
+     * `foreach ($tokens as ...)` looking for top-level T_USE tokens. The
+     * result is stable across calls during a single phpcs pass over a
+     * file, but several sniffs call it once per T_FUNCTION
+     * (DocBlockThrowsSniff, DocBlockVarSniff, UseWithAliasingSniff). On a
+     * large method-heavy controller that turns a per-file O(file_size)
+     * walk into per-method O(methods * file_size). Cache the parsed
+     * result so each file is parsed at most once per pass.
+     *
+     * Cache invalidation has to survive phpcbf's fix loop, which re-
+     * tokenizes the same file in-place on the same File object after
+     * each fix iteration. Token count alone is not sufficient — a fix
+     * that renames an alias (`use Foo as Bar;` -> `use Foo as Baz;`)
+     * leaves the token count unchanged. We therefore also store the
+     * concrete statement strings on the way in and re-verify them
+     * against the live tokens before trusting a cache hit. The
+     * verification is O(num_use_statements * avg_use_length), typically
+     * just a handful of token reads, so it stays cheap.
+     *
+     * @var array<string, array{count: int, statements: array<string, array<string, mixed>>}>
+     */
+    private static array $useStatementsCache = [];
+
+    /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      *
      * @return array<string, array<string, mixed>>
@@ -20,6 +46,15 @@ trait UseStatementsTrait
     protected function getUseStatements(File $phpcsFile): array
     {
         $tokens = $phpcsFile->getTokens();
+        $cacheKey = $phpcsFile->getFilename();
+        $tokenCount = count($tokens);
+        if (
+            isset(self::$useStatementsCache[$cacheKey])
+            && self::$useStatementsCache[$cacheKey]['count'] === $tokenCount
+            && $this->useStatementsCacheStillValid(self::$useStatementsCache[$cacheKey]['statements'], $tokens)
+        ) {
+            return self::$useStatementsCache[$cacheKey]['statements'];
+        }
 
         $statements = [];
         foreach ($tokens as $index => $token) {
@@ -81,10 +116,81 @@ trait UseStatementsTrait
                 'fullName' => ltrim($fullName, '\\'),
                 'shortName' => $shortName,
                 'start' => $index,
+                'cacheFingerprint' => $this->buildUseStatementFingerprint($tokens, $index, $semicolonIndex),
             ];
         }
 
+        self::$useStatementsCache[$cacheKey] = [
+            'count' => $tokenCount,
+            'statements' => $statements,
+        ];
+
         return $statements;
+    }
+
+    /**
+     * Concatenate the raw content of every token in [$start, $end] inclusive.
+     *
+     * Used as a fingerprint for cache invalidation: when a phpcbf fix
+     * rewrites the inside of a `use` line without changing the total
+     * token count of the file, the fingerprint differs and the cached
+     * entry is rejected.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     * @param int $start
+     * @param int $end
+     *
+     * @return string
+     */
+    private function buildUseStatementFingerprint(array $tokens, int $start, int $end): string
+    {
+        $fingerprint = '';
+        for ($i = $start; $i <= $end; $i++) {
+            if (!isset($tokens[$i])) {
+                break;
+            }
+            $fingerprint .= $tokens[$i]['content'];
+        }
+
+        return $fingerprint;
+    }
+
+    /**
+     * Verify a cache entry against the live tokens.
+     *
+     * For every cached use statement, check that the live tokens at the
+     * recorded [start, end] range still produce the same concatenated
+     * content (the fingerprint stored when the entry was created). This
+     * catches:
+     *   - structural edits that shifted positions without changing
+     *     overall token count (cached T_USE no longer at `start`);
+     *   - in-place rewrites that preserve token count, e.g. renaming
+     *     an imported alias to a different identifier of the same shape;
+     *   - any whitespace/comment edit inside the use statement.
+     *
+     * Cost per call is O(num_use_statements * avg_use_length), typically
+     * just a handful of token reads.
+     *
+     * @param array<string, array<string, mixed>> $statements
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return bool
+     */
+    private function useStatementsCacheStillValid(array $statements, array $tokens): bool
+    {
+        foreach ($statements as $statement) {
+            $start = $statement['start'];
+            if (!isset($tokens[$start]) || $tokens[$start]['code'] !== T_USE) {
+                return false;
+            }
+
+            $live = $this->buildUseStatementFingerprint($tokens, $start, $statement['end']);
+            if ($live !== $statement['cacheFingerprint']) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #62 and #63. Two changes in `UseStatementsTrait` / `DocBlockThrowsSniff`:

1. **Cache `getUseStatements()` per file** in `UseStatementsTrait`. The result is currently rebuilt once per `T_FUNCTION` by every sniff that uses the trait, but it's a per-file quantity. On a large method-heavy controller this turns a per-file O(file_size) walk into per-method O(methods × file_size). The trait is used by `DocBlockThrowsSniff`, `DocBlockVarSniff`, and `UseWithAliasingSniff`, so all three benefit.
2. **Bound the `T_DOUBLE_COLON` lookup in `extractExceptions()` to the current statement.** The original code searched up to `$scopeCloser` (the method's closing brace), which on long bodies could pick up an unrelated `::` operator from a later statement and silently use it to gate exception collection for *this* throw. Bounding to the next `;` is both faster and more correct.

## Why this was slow

`getUseStatements()` iterates every token in the file:

```php
foreach ($tokens as $index => $token) {
    if ($token['code'] !== T_USE || $token['level'] > 0) {
        continue;
    }
    // ... parse the use line
}
```

That's an O(file_size) walk per call. `DocBlockThrowsSniff::compareExceptionsAndAnnotations()` calls it once per method, so an 11k-token controller with ~100 methods does ~1.1M token reads per file just to repeatedly rebuild the same use list. Same shape of bug we caught in `AbstractSniff::getClassName()` in #62.

## Cache invalidation

The static cache has to survive phpcbf's fix loop, which calls `$file->reloadContent(); $file->process();` on the **same File object** after each fix iteration. Token count alone isn't enough: a fix that renames an alias (`use Foo as Bar;` -> `use Foo as Baz;`) leaves the count unchanged, and other sniffs would then read stale aliases out of the cache. (Caught in codex review on the first draft.)

The cache therefore stores a content fingerprint of each use statement range (`start..end` token contents concatenated) and re-verifies it against the live tokens on every cache hit. The verification is O(num_uses × avg_use_length) — typically a handful of token reads — so the cache stays cheap.

## Benchmarks

Measured on the same 1095-file CakePHP 5 app from #62 / #63 (`ResidentsController.php`, 11k LOC, ~100 actions). The `phpcs --report=performance` figures are the per-sniff CPU times reported by phpcs itself, so they're not affected by background system load the way wall-clock figures are:

| | Before (master) | After this PR |
|---|---|---|
| DocBlockThrows on `ResidentsController.php` (median, 3 runs) | ~3.25s | **~0.08s** (≈ 40× speedup) |
| DocBlockThrows across all 1095 files, `parallel=1` (median, 3 runs) | ~11.32s | **~0.86s** (≈ 13× speedup) |

DocBlockThrows was the #1 hot spot in the perf report after #62 / #63 landed (~19% of total time). It's now down to ~1–2%.

## Why not the combined-scan refactor

An earlier draft of this PR replaced the four overlapping body scans in `process()` (`extractExceptions` / `containsComplexThrowToken` / `containsThrowToken` / `containsCatchToken`) with a single combined pass that tracked nested-closure boundaries via a running cursor. It worked correctly, but a controlled 3-run measurement showed it brought the sniff from 3.25s to 3.21s on `ResidentsController.php` — completely within noise. The four-scan structure looks expensive but the inner-loop short-circuits made it cheap in practice; the actual hot path turned out to be the un-cached `getUseStatements()` call called from `compareExceptionsAndAnnotations()`. So the refactor was dropped; the existing four helpers are kept untouched.

## Verification

- Existing PHPUnit suite passes (100 tests / 122 assertions).
- `composer cs-check` and `composer stan` on this repo: clean.
- Output diff across all sniffs and all 1095 files of the activity-pro test corpus: identical violations before vs after.
- Cache invalidation: a fixture that renames an aliased use statement in place (same token count, different alias) correctly produces fresh parse output on the next call; the cache rejects the stale entry via fingerprint mismatch.
- `codex review --uncommitted` on the final patch: addressed the one P2 finding (cache invalidation strength) before commit.
