### PR TITLE
Perf: cache docblock FQCN lookups

### DIFF
--- a/PhpCollective/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
+++ b/PhpCollective/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniff.php
@@ -24,6 +24,23 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
     use CommentingTrait;
 
     /**
+     * Per-file runtime cache for the current phpcs pass.
+     *
+     * The sniff registers on several token types that can all point at the
+     * same doc block, so without deduplication the same comment can be parsed
+     * multiple times in one pass. The file-level namespace and use statements
+     * are also stable within one pass and should only be built once.
+     *
+     * phpcbf may re-tokenize the same File object for a new pass while keeping
+     * the token count unchanged. We detect that by the stack pointer order:
+     * token processing is monotonic within a pass, so a non-increasing pointer
+     * means a fresh pass and the cache is reset.
+     *
+     * @var array<string, array{count: int, lastStackPointer: int, namespace: string|null, processedDocBlocks: array<int, true>, useStatements: array<string, string>|null}>
+     */
+    private static array $runtimeCache = [];
+
+    /**
      * @var array<string>
      */
     public static array $whitelistedTypes = [
@@ -73,13 +90,18 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPointer): void
     {
-        $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, $stackPointer);
+        $tokens = $phpcsFile->getTokens();
+        $this->initializeRuntimeCache($phpcsFile, (int)$stackPointer, $tokens);
+
+        $docBlockEndIndex = $this->findRelatedDocBlock($phpcsFile, (int)$stackPointer);
 
         if (!$docBlockEndIndex) {
             return;
         }
-
-        $tokens = $phpcsFile->getTokens();
+        if ($this->hasProcessedDocBlock($phpcsFile, $docBlockEndIndex)) {
+            return;
+        }
+        $this->markDocBlockProcessed($phpcsFile, $docBlockEndIndex);
 
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
@@ -241,6 +263,11 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
      */
     protected function getNamespace(File $phpcsFile): string
     {
+        $cacheKey = $phpcsFile->getFilename();
+        if (self::$runtimeCache[$cacheKey]['namespace'] !== null) {
+            return self::$runtimeCache[$cacheKey]['namespace'];
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         $namespaceStart = null;
@@ -254,6 +281,8 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
             break;
         }
         if (!$namespaceStart) {
+            self::$runtimeCache[$cacheKey]['namespace'] = '';
+
             return '';
         }
 
@@ -269,6 +298,7 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
         );
 
         $namespace = trim($phpcsFile->getTokensAsString(($namespaceStart), ($namespaceEnd - $namespaceStart)));
+        self::$runtimeCache[$cacheKey]['namespace'] = $namespace;
 
         return $namespace;
     }
@@ -303,6 +333,11 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
      */
     protected function parseUseStatements(File $phpcsFile): array
     {
+        $cacheKey = $phpcsFile->getFilename();
+        if (self::$runtimeCache[$cacheKey]['useStatements'] !== null) {
+            return self::$runtimeCache[$cacheKey]['useStatements'];
+        }
+
         $useStatements = [];
         $tokens = $phpcsFile->getTokens();
 
@@ -334,6 +369,63 @@ class FullyQualifiedClassNameInDocBlockSniff implements Sniff
             $useStatements[$className] = $useStatement;
         }
 
+        self::$runtimeCache[$cacheKey]['useStatements'] = $useStatements;
+
         return $useStatements;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPointer
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return void
+     */
+    protected function initializeRuntimeCache(File $phpcsFile, int $stackPointer, array $tokens): void
+    {
+        $cacheKey = $phpcsFile->getFilename();
+        $tokenCount = count($tokens);
+        if (
+            !isset(self::$runtimeCache[$cacheKey])
+            || self::$runtimeCache[$cacheKey]['count'] !== $tokenCount
+            || $stackPointer <= self::$runtimeCache[$cacheKey]['lastStackPointer']
+        ) {
+            self::$runtimeCache[$cacheKey] = [
+                'count' => $tokenCount,
+                'lastStackPointer' => $stackPointer,
+                'namespace' => null,
+                'processedDocBlocks' => [],
+                'useStatements' => null,
+            ];
+
+            return;
+        }
+
+        self::$runtimeCache[$cacheKey]['lastStackPointer'] = $stackPointer;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $docBlockEndIndex
+     *
+     * @return bool
+     */
+    protected function hasProcessedDocBlock(File $phpcsFile, int $docBlockEndIndex): bool
+    {
+        $cacheKey = $phpcsFile->getFilename();
+
+        return isset(self::$runtimeCache[$cacheKey]['processedDocBlocks'][$docBlockEndIndex]);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $docBlockEndIndex
+     *
+     * @return void
+     */
+    protected function markDocBlockProcessed(File $phpcsFile, int $docBlockEndIndex): void
+    {
+        $cacheKey = $phpcsFile->getFilename();
+        self::$runtimeCache[$cacheKey]['processedDocBlocks'][$docBlockEndIndex] = true;
     }
 }

--- a/tests/PhpCollective/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/FullyQualifiedClassNameInDocBlockSniffTest.php
@@ -17,7 +17,7 @@ class FullyQualifiedClassNameInDocBlockSniffTest extends TestCase
      */
     public function testDocBlockConstSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new FullyQualifiedClassNameInDocBlockSniff(), 11);
+        $this->assertSnifferFindsErrors(new FullyQualifiedClassNameInDocBlockSniff(), 7);
     }
 
     /**


### PR DESCRIPTION
## Summary

Cache file-level work in `FullyQualifiedClassNameInDocBlockSniff` and avoid reprocessing the same doc block multiple times in a single phpcs pass.

This does two things:

- deduplicates doc block processing inside the sniff's current broad registration set (`T_CLASS`, `T_INTERFACE`, `T_TRAIT`, `T_FUNCTION`, `T_VARIABLE`, `T_COMMENT`), so the same doc block is only parsed once per pass;
- caches the file namespace and parsed `use` statements for the lifetime of that pass instead of rebuilding them for every class-name lookup.

The cache is pass-scoped, not content-scoped: it resets when token processing restarts from an earlier stack pointer, which is what phpcbf does after re-tokenizing a file for a new fix loop.

## Why

After #63 and #64 landed, `PhpCollective.Commenting.FullyQualifiedClassNameInDocBlock` became the dominant repo-local hotspot on large docblock-heavy files.

The old code had two expensive patterns:

- `parseUseStatements()` walked the whole file every time `findUseStatementForClassName()` was called;
- the same related doc block could be processed repeatedly because multiple registered token types on the same declaration path all resolved to the same doc block.

That meant a large method-heavy file with repeated `@param` / `@return` / `@throws` tags paid for the same file-level scans many times.

## Behavior

This also removes duplicate error reporting for the same doc block. The existing fixture still fixes to the same output, but the unique violation count drops from `11` to `7`, which is what the updated test now asserts.

## Benchmark

Measured on a synthetic large file with 430 repeated methods and docblocks:

- before: `PhpCollective.Commenting.FullyQualifiedClassNameInDocBlock` about `49.99s`
- after: `PhpCollective.Commenting.FullyQualifiedClassNameInDocBlock` about `1.35s`

## Verification

- `composer cs-fix`
- `composer test`
- `composer stan`
