### PR TITLE
Perf: cache UseStatementSniff getUseStatements across fix iterations

### DIFF
--- a/PhpCollective/Sniffs/Namespaces/UseStatementSniff.php
+++ b/PhpCollective/Sniffs/Namespaces/UseStatementSniff.php
@@ -41,6 +41,22 @@ class UseStatementSniff implements Sniff
     protected ?string $className = null;
 
     /**
+     * Per-file cache of `getUseStatements()` output.
+     *
+     * The sniff's existing instance-level cache (`$this->existingStatements`)
+     * already covers repeated calls within a single phpcs pass. The
+     * static cache adds protection across phpcbf fix iterations, where
+     * `populateTokenListeners()` instantiates a fresh sniff object per
+     * pass and resets the instance cache. Token count alone is not a
+     * strong enough invalidation key (an alias rename can keep it
+     * constant), so cached entries also store a content fingerprint of
+     * each use statement range and re-verify it before being trusted.
+     *
+     * @var array<string, array{count: int, statements: array<string, array<string, mixed>>, fingerprints: array<int, array{start: int, end: int, fingerprint: string}>}>
+     */
+    private static array $useStatementsFileCache = [];
+
+    /**
      * @inheritDoc
      */
     public function register(): array
@@ -1120,8 +1136,19 @@ class UseStatementSniff implements Sniff
     protected function getUseStatements(File $phpcsFile): array
     {
         $tokens = $phpcsFile->getTokens();
+        $cacheKey = $phpcsFile->getFilename();
+        $tokenCount = count($tokens);
+        if (
+            isset(self::$useStatementsFileCache[$cacheKey])
+            && self::$useStatementsFileCache[$cacheKey]['count'] === $tokenCount
+            && self::$useStatementsFileCache[$cacheKey]['fingerprints'] !== []
+            && $this->useStatementsCacheStillValid(self::$useStatementsFileCache[$cacheKey]['fingerprints'], $tokens)
+        ) {
+            return self::$useStatementsFileCache[$cacheKey]['statements'];
+        }
 
         $statements = [];
+        $fingerprints = [];
         foreach ($tokens as $index => $token) {
             if ($token['code'] !== T_USE || $token['level'] > 0) {
                 continue;
@@ -1138,6 +1165,9 @@ class UseStatementSniff implements Sniff
             }
 
             $semicolonIndex = $phpcsFile->findNext(T_SEMICOLON, $useStatementStartIndex + 1);
+            if ($semicolonIndex === false) {
+                continue;
+            }
             $useStatementEndIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $semicolonIndex - 1, null, true);
             if ($useStatementEndIndex === false) {
                 continue;
@@ -1177,9 +1207,74 @@ class UseStatementSniff implements Sniff
                 'shortName' => $shortName,
                 'start' => $index,
             ];
+            $fingerprints[] = [
+                'start' => (int)$index,
+                'end' => $semicolonIndex,
+                'fingerprint' => $this->buildUseStatementFingerprint($tokens, (int)$index, $semicolonIndex),
+            ];
         }
 
+        self::$useStatementsFileCache[$cacheKey] = [
+            'count' => $tokenCount,
+            'statements' => $statements,
+            'fingerprints' => $fingerprints,
+        ];
+
         return $statements;
+    }
+
+    /**
+     * Verify a cached `getUseStatements()` entry against the live tokens.
+     *
+     * Matches the invalidation strategy used by `UseStatementsTrait` and
+     * `FullyQualifiedClassNameInDocBlockSniff`: re-fingerprint each
+     * recorded use statement range and bail if anything differs. Catches
+     * in-place edits that preserve token count (e.g. alias rename).
+     *
+     * Cost: O(num_uses * avg_use_length) - a handful of token reads.
+     *
+     * @param array<int, array{start: int, end: int, fingerprint: string}> $fingerprints
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return bool
+     */
+    private function useStatementsCacheStillValid(array $fingerprints, array $tokens): bool
+    {
+        foreach ($fingerprints as $entry) {
+            $start = $entry['start'];
+            if (!isset($tokens[$start]) || $tokens[$start]['code'] !== T_USE) {
+                return false;
+            }
+
+            $live = $this->buildUseStatementFingerprint($tokens, $start, $entry['end']);
+            if ($live !== $entry['fingerprint']) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Concatenate the content of every token in [$start, $end] inclusive.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     * @param int $start
+     * @param int $end
+     *
+     * @return string
+     */
+    private function buildUseStatementFingerprint(array $tokens, int $start, int $end): string
+    {
+        $fingerprint = '';
+        for ($i = $start; $i <= $end; $i++) {
+            if (!isset($tokens[$i])) {
+                break;
+            }
+            $fingerprint .= $tokens[$i]['content'];
+        }
+
+        return $fingerprint;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a per-file cache to `UseStatementSniff::getUseStatements()`, the same shape as #64 and #65.

`UseStatementSniff` has its own `getUseStatements()` implementation that duplicates `UseStatementsTrait::getUseStatements()` (the one cached in #64). The existing instance-level cache via `$existingStatements` covers repeated calls within a single phpcs pass; the new static cache adds coverage across phpcbf fix iterations, where `populateTokenListeners()` creates fresh sniff instances per pass and resets the instance cache.

## Cache invalidation

Same fingerprint-based scheme introduced in #64. Token count alone is not strong enough — an alias rename keeps it constant. Cached entries record a content fingerprint of each use statement range and re-verify them against the live tokens before being trusted.

Defensive belt-and-braces: refuse to serve a cached empty result. Files with no `use` statements don't benefit from caching anyway, and skipping the cache for empty results means we won't serve stale state in the corner case where a fix adds a first use statement while another simultaneous fix happens to keep the overall token count unchanged.

## Why not the trait

`UseStatementSniff::getUseStatements()` is *almost* a duplicate of `UseStatementsTrait::getUseStatements()` (the one cached in #64), but with a slightly different result shape (no `'statement'` field). Refactoring this sniff onto the trait is doable but out of scope for a perf-only PR — same cache shape, kept local.

## Benchmarks

Measured on the same 1095-file CakePHP 5 app from #62 / #63 / #64 / #65. Per-sniff CPU times from `phpcs --parallel=1 --report=performance`:

| Sniff | Before this PR | After this PR |
|---|---|---|
| `PhpCollective.Namespaces.UseStatement` | ~3.36s | **~2.08s** (-38%) |

## Note

An earlier draft of this PR also added a cache to `FullyQualifiedClassNameInDocBlockSniff::parseUseStatements()` / `::getNamespace()`. Those changes were dropped after #65 landed with a different (monotonic-stack-pointer) caching scheme covering the same hot path.

## Verification

- Existing PHPUnit suite passes (100 tests / 122 assertions).
- `composer cs-check` and `composer stan` on this repo: clean.
- Output diff on the activity-pro test corpus: identical violations before vs after.
- `codex review --uncommitted` on the original (broader) draft flagged P2 cache-invalidation concerns; the empty-result skip in this final version was added in response.