### PR TITLE
Fix phpcbf conflict on anonymous class bodies in ConsistentIndent

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
@@ -77,6 +77,9 @@ class ConsistentIndentSniff extends AbstractSniff
         if ($this->isInsideSwitchCase($phpcsFile, $nextToken, $tokens)) {
             return;
         }
+        if ($this->isInsideAnonClass($tokens, $nextToken)) {
+            return;
+        }
         if ($tokens[$nextToken]['code'] === T_COMMENT || $tokens[$nextToken]['code'] === T_DOC_COMMENT_OPEN_TAG) {
             return;
         }
@@ -475,6 +478,38 @@ class ConsistentIndentSniff extends AbstractSniff
 
         foreach ($tokens[$stackPtr]['conditions'] as $code) {
             if ($code === T_SWITCH) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the current position is inside an anonymous class body.
+     *
+     * Anonymous classes are frequently passed as arguments to a multi-line
+     * function call (e.g. `new Service(new class () extends Base { ... })`).
+     * In that case the class scope is opened inside an unclosed parenthesis,
+     * so the body carries one continuation indent level that `getExpectedIndent()`
+     * (which only counts scope conditions) cannot see. `Generic.WhiteSpace.ScopeIndent`
+     * does account for it, so flagging here produces a fixer conflict where the two
+     * sniffs dedent/indent the same lines forever ("FAILED TO FIX"). Defer to
+     * ScopeIndent for anonymous class bodies, the same way closures are skipped.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     * @param int $stackPtr
+     *
+     * @return bool
+     */
+    protected function isInsideAnonClass(array $tokens, int $stackPtr): bool
+    {
+        if (empty($tokens[$stackPtr]['conditions'])) {
+            return false;
+        }
+
+        foreach ($tokens[$stackPtr]['conditions'] as $code) {
+            if ($code === T_ANON_CLASS) {
                 return true;
             }
         }

--- a/tests/_data/ConsistentIndent/after.php
+++ b/tests/_data/ConsistentIndent/after.php
@@ -108,4 +108,21 @@ class FixMe
             ?? $params['home_id']
             ?? null;
     }
+
+    public function anonClassAsArgumentShouldNotBeFlagged(array $payload): object
+    {
+        return new Service(
+            new class ($payload) extends Base {
+                public function __construct(private array $payload)
+                {
+                    parent::__construct();
+                }
+
+                public function defaultProvider(): string
+                {
+                    return 'codex';
+                }
+            },
+        );
+    }
 }

--- a/tests/_data/ConsistentIndent/before.php
+++ b/tests/_data/ConsistentIndent/before.php
@@ -108,4 +108,21 @@ class FixMe
             ?? $params['home_id']
             ?? null;
     }
+
+    public function anonClassAsArgumentShouldNotBeFlagged(array $payload): object
+    {
+        return new Service(
+            new class ($payload) extends Base {
+                public function __construct(private array $payload)
+                {
+                    parent::__construct();
+                }
+
+                public function defaultProvider(): string
+                {
+                    return 'codex';
+                }
+            },
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`PhpCollective.WhiteSpace.ConsistentIndent` and the bundled `Generic.WhiteSpace.ScopeIndent` disagree on the expected indentation of an **anonymous class body** when the anonymous class is passed as an argument to a multi-line function call:

```php
return new Service(
    new class ($payload) extends Base {
        public function foo(): void {}
    },
);
```

The class scope is opened **inside an unclosed parenthesis**, so the body carries one extra continuation indent level. `getExpectedIndent()` only counts scope `conditions`, so it misses that level and dedents the body, while `ScopeIndent` re-indents it. `phpcbf` then oscillates between the two until it hits the loop limit and reports `FAILED TO FIX` (exit 7) — the file becomes unfixable.

## Fix

Defer to `ScopeIndent` for anonymous class bodies — the same way closures, arrays and switch/case blocks are already skipped — via a new `isInsideAnonClass()` guard.

Before: `phpcbf` ran the full 50 loops (~75s) and reported `FAILED TO FIX` (a negative net fix count, the tell-tale sign of two fixers fighting).
After: the file converges in one pass (~8s), no conflict.

## Tests

Added a correctly-indented anonymous-class-as-argument case to the `ConsistentIndent` before/after fixtures. Before this change the fixer wrongly dedented the body (fixer test red); now it is left untouched and no longer flagged.