### PR TITLE
Fix DocBlockVar fixer corrupting callable/Closure types

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockVarSniff.php
@@ -283,19 +283,22 @@ class DocBlockVarSniff extends AbstractSniff
         }
 
         $content = $tokens[$classNameIndex]['content'];
-        // Skip types whose syntax contains internal spaces/structure that the
-        // simple first-space split below cannot handle: generics/array-shapes
-        // (`{`, `<`) and callable/Closure signatures (`(int): string`). Without
-        // this the fixer would split mid-type and corrupt the annotation.
-        if (str_contains($content, '{') || str_contains($content, '<') || str_contains($content, '(')) {
-            return;
-        }
 
         $appendix = '';
         $spaceIndex = strpos($content, ' ');
-        if ($spaceIndex) {
+        if ($spaceIndex !== false) {
             $appendix = substr($content, $spaceIndex);
             $content = substr($content, 0, $spaceIndex);
+        }
+
+        // Skip types whose syntax contains internal structure that the simple
+        // first-space split above cannot handle: generics/array-shapes (`{`,
+        // `<`) and callable/Closure signatures (`(int): string`). Their opening
+        // token sits before the first space, so checking the split-off type
+        // catches them while leaving a trailing description like `Foo (note)`
+        // alone. Without this the fixer would split mid-type and corrupt it.
+        if (str_contains($content, '{') || str_contains($content, '<') || str_contains($content, '(')) {
+            return;
         }
 
         if (!$content) {

--- a/PhpCollective/Sniffs/Commenting/DocBlockVarSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockVarSniff.php
@@ -283,7 +283,11 @@ class DocBlockVarSniff extends AbstractSniff
         }
 
         $content = $tokens[$classNameIndex]['content'];
-        if (str_contains($content, '{') || str_contains($content, '<')) {
+        // Skip types whose syntax contains internal spaces/structure that the
+        // simple first-space split below cannot handle: generics/array-shapes
+        // (`{`, `<`) and callable/Closure signatures (`(int): string`). Without
+        // this the fixer would split mid-type and corrupt the annotation.
+        if (str_contains($content, '{') || str_contains($content, '<') || str_contains($content, '(')) {
             return;
         }
 

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockVarSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockVarSniffTest.php
@@ -17,7 +17,7 @@ class DocBlockVarSniffTest extends TestCase
      */
     public function testDocBlockConstSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new DocBlockVarSniff(), 1);
+        $this->assertSnifferFindsErrors(new DocBlockVarSniff(), 2);
     }
 
     /**

--- a/tests/_data/DocBlockVar/after.php
+++ b/tests/_data/DocBlockVar/after.php
@@ -70,4 +70,9 @@ class FixMe
      * @var MyClass[]
      */
     protected array $objects;
+
+    /**
+     * @var \Closure(string): string
+     */
+    protected ?Closure $transformer = null;
 }

--- a/tests/_data/DocBlockVar/after.php
+++ b/tests/_data/DocBlockVar/after.php
@@ -75,4 +75,9 @@ class FixMe
      * @var \Closure(string): string
      */
     protected ?Closure $transformer = null;
+
+    /**
+     * @var string|null (deprecated)
+     */
+    protected ?string $note;
 }

--- a/tests/_data/DocBlockVar/before.php
+++ b/tests/_data/DocBlockVar/before.php
@@ -70,4 +70,9 @@ class FixMe
      * @var MyClass[]
      */
     protected array $objects;
+
+    /**
+     * @var \Closure(string): string
+     */
+    protected ?Closure $transformer = null;
 }

--- a/tests/_data/DocBlockVar/before.php
+++ b/tests/_data/DocBlockVar/before.php
@@ -75,4 +75,9 @@ class FixMe
      * @var \Closure(string): string
      */
     protected ?Closure $transformer = null;
+
+    /**
+     * @var string (deprecated)
+     */
+    protected ?string $note;
 }


### PR DESCRIPTION
## Problem

The `DocBlockVar` fixer corrupts callable/`Closure` property types when it appends a
missing `null`.

`handle()` splits the doc type on its first space to peel off a trailing comment,
assuming the type itself has no internal spaces. A callable/`Closure` signature has a
space after the colon, so the split cuts the type in half:

~~~text
/**
 * @var \Closure(string): string
 */
protected ?\Closure $x = null;
~~~

`phpcbf` turns that into invalid output:

~~~text
 * @var \Closure(string):|null string
~~~

PHPStan then rejects it as an unparseable doc type ("Unexpected token (").

## Fix

Skip types whose syntax contains internal spaces/structure that the simple first-space
split cannot handle. Generics (`<`) and array shapes (`{`) are already skipped; this adds
callable/`Closure` signatures (`(`). The fixer then leaves such annotations untouched
instead of mangling them.

A regression fixture (a `?Closure` property with a `\Closure(string): string` type) is
added to `tests/_data/DocBlockVar`; the fixer must leave it unchanged.

Found while it corrupted a real `?Closure` property annotation in another project.
