### PR TITLE
Add missing function aliases to RemoveFunctionAlias sniff

### DIFF
--- a/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -25,6 +25,7 @@ class RemoveFunctionAliasSniff implements Sniff
         'is_long' => 'is_int',
         'is_real' => 'is_float',
         'is_double' => 'is_float',
+        'doubleval' => 'floatval',
         'is_writeable' => 'is_writable',
         'join' => 'implode',
         'key_exists' => 'array_key_exists', // Deprecated function
@@ -32,9 +33,10 @@ class RemoveFunctionAliasSniff implements Sniff
         'strchr' => 'strstr',
         'ini_alter' => 'ini_set',
         'fputs' => 'fwrite',
-        'die' => 'exit',
         'chop' => 'rtrim',
-        'print' => 'echo',
+        'pos' => 'current',
+        'show_source' => 'highlight_file',
+        'user_error' => 'trigger_error',
     ];
 
     /**

--- a/tests/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\PHP;
+
+use PhpCollective\Sniffs\PHP\RemoveFunctionAliasSniff;
+use PhpCollective\Test\TestCase;
+
+class RemoveFunctionAliasSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testRemoveFunctionAliasSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new RemoveFunctionAliasSniff(), 16, 16);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRemoveFunctionAliasFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new RemoveFunctionAliasSniff(), 16);
+    }
+}

--- a/tests/_data/RemoveFunctionAlias/after.php
+++ b/tests/_data/RemoveFunctionAlias/after.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Type check aliases.
+     */
+    public function typeChecks($x): bool
+    {
+        return is_int($x) || is_int($x) || is_float($x) || is_float($x) || is_writable($x);
+    }
+
+    /**
+     * Conversion alias deprecated in PHP 8.5.
+     */
+    public function conversion($x): float
+    {
+        return floatval($x);
+    }
+
+    /**
+     * Array and string aliases.
+     */
+    public function arraysAndStrings(array $list, string $string)
+    {
+        $count = count($list);
+        $first = current($list);
+        $exists = array_key_exists('a', $list);
+        $joined = implode(',', $list);
+        $part = strstr($string, 'a');
+        $trimmed = rtrim($string);
+
+        return [$count, $first, $exists, $joined, $part, $trimmed];
+    }
+
+    /**
+     * Resource and runtime aliases.
+     */
+    public function runtime($handle, string $file): void
+    {
+        ini_set('display_errors', '1');
+        fwrite($handle, 'foo');
+        highlight_file($file);
+        trigger_error('Something went wrong');
+    }
+
+    /**
+     * Method calls, static calls, declarations and instantiations must not be touched.
+     */
+    public function chop(string $string): string
+    {
+        $a = $this->join(',', []);
+        $b = static::sizeof([]);
+        $c = new Join();
+        $d = $this->pos;
+
+        return $string . $a . $b . $c . $d;
+    }
+}

--- a/tests/_data/RemoveFunctionAlias/before.php
+++ b/tests/_data/RemoveFunctionAlias/before.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Type check aliases.
+     */
+    public function typeChecks($x): bool
+    {
+        return is_integer($x) || is_long($x) || is_real($x) || is_double($x) || is_writeable($x);
+    }
+
+    /**
+     * Conversion alias deprecated in PHP 8.5.
+     */
+    public function conversion($x): float
+    {
+        return doubleval($x);
+    }
+
+    /**
+     * Array and string aliases.
+     */
+    public function arraysAndStrings(array $list, string $string)
+    {
+        $count = sizeof($list);
+        $first = pos($list);
+        $exists = key_exists('a', $list);
+        $joined = join(',', $list);
+        $part = strchr($string, 'a');
+        $trimmed = chop($string);
+
+        return [$count, $first, $exists, $joined, $part, $trimmed];
+    }
+
+    /**
+     * Resource and runtime aliases.
+     */
+    public function runtime($handle, string $file): void
+    {
+        ini_alter('display_errors', '1');
+        fputs($handle, 'foo');
+        show_source($file);
+        user_error('Something went wrong');
+    }
+
+    /**
+     * Method calls, static calls, declarations and instantiations must not be touched.
+     */
+    public function chop(string $string): string
+    {
+        $a = $this->join(',', []);
+        $b = static::sizeof([]);
+        $c = new Join();
+        $d = $this->pos;
+
+        return $string . $a . $b . $c . $d;
+    }
+}


### PR DESCRIPTION
`RemoveFunctionAlias` already covered `is_double`, `is_integer`, `is_long` and `is_real`, but was missing `doubleval`, which PHP deprecates in the same batch.

### Added mappings

| alias | replacement |
| --- | --- |
| `doubleval` | `floatval` |
| `pos` | `current` |
| `show_source` | `highlight_file` |
| `user_error` | `trigger_error` |

The last three are the remaining entries from the PHP manual alias list that were not covered yet.

### Removed dead mappings

`die` and `print` could never match. The sniff registers on `T_STRING`, while PHP_CodeSniffer tokenizes those as `T_EXIT` and `T_PRINT`, so `register()` never saw them. `die` is already covered by `PhpCollective.PHP.Exit`, and `print` is a language construct, not a function alias.

### Test coverage

The sniff had none. Added a `before.php` / `after.php` fixture pair covering every mapping, plus the cases that must stay untouched: method calls, static calls, method declarations and instantiation.
