### PR TITLE
Fix DeprecatedFunctions override and PHP 8.5 tokenizer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - '8.1'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Setup PHP

--- a/PhpCollective/Sniffs/Commenting/FileDocBlockSniff.php
+++ b/PhpCollective/Sniffs/Commenting/FileDocBlockSniff.php
@@ -233,11 +233,11 @@ class FileDocBlockSniff extends AbstractSniff
 
     /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int|null $fileDocBlockStartPosition
+     * @param int $fileDocBlockStartPosition
      *
      * @return array<string>
      */
-    protected function getFileDocBlockLines(File $phpcsFile, ?int $fileDocBlockStartPosition): array
+    protected function getFileDocBlockLines(File $phpcsFile, int $fileDocBlockStartPosition): array
     {
         $tokens = $phpcsFile->getTokens();
         $fileDocBlockEndPosition = $tokens[$fileDocBlockStartPosition]['comment_closer'];

--- a/PhpCollective/Sniffs/PHP/VoidCastSniff.php
+++ b/PhpCollective/Sniffs/PHP/VoidCastSniff.php
@@ -19,11 +19,23 @@ use PHP_CodeSniffer\Util\Tokens;
 class VoidCastSniff implements Sniff
 {
     /**
+     * PHP 8.5 tokenizes the whole cast, inner whitespace included, as a single T_VOID_CAST
+     * token. Older versions have no such cast and produce `(`, `void`, `)` instead, so both
+     * forms have to be registered.
+     *
      * @inheritDoc
      */
     public function register(): array
     {
-        return [T_OPEN_PARENTHESIS];
+        $tokens = [T_OPEN_PARENTHESIS];
+
+        if (defined('T_VOID_CAST')) {
+            /** @var int $voidCast */
+            $voidCast = constant('T_VOID_CAST');
+            $tokens[] = $voidCast;
+        }
+
+        return $tokens;
     }
 
     /**
@@ -32,6 +44,15 @@ class VoidCastSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
+
+        // PHP 8.5+: single token carrying the whole cast.
+        if ($tokens[$stackPtr]['type'] === 'T_VOID_CAST') {
+            $this->checkSpacingBeforeCast($phpcsFile, $stackPtr);
+            $this->checkSingleTokenCastContent($phpcsFile, $stackPtr);
+            $this->checkSpacingAfterCast($phpcsFile, $stackPtr);
+
+            return;
+        }
 
         // Check if this is a (void) cast pattern
         $nextNonWhitespace = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
@@ -137,6 +158,52 @@ class VoidCastSniff implements Sniff
     }
 
     /**
+     * Check that there's no space within the cast (void) not ( void ).
+     *
+     * On PHP 8.5+ the inner whitespace is part of the T_VOID_CAST token itself, so it has to
+     * be read off the token content rather than from surrounding tokens.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return void
+     */
+    protected function checkSingleTokenCastContent(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (!preg_match('/^\((\s*)(\w+)(\s*)\)$/', $tokens[$stackPtr]['content'], $matches)) {
+            return;
+        }
+
+        $replacement = '(' . $matches[2] . ')';
+
+        if ($matches[1] !== '') {
+            $fix = $phpcsFile->addFixableError(
+                'No space expected after opening parenthesis in void cast',
+                $stackPtr,
+                'SpaceAfterOpenParen',
+            );
+            if ($fix) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+            }
+        }
+
+        if ($matches[3] === '') {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'No space expected before closing parenthesis in void cast',
+            $stackPtr,
+            'SpaceBeforeCloseParen',
+        );
+        if ($fix) {
+            $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+        }
+    }
+
+    /**
      * Check that there's exactly one space after the cast
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
@@ -160,7 +227,10 @@ class VoidCastSniff implements Sniff
                 'MissingSpaceAfter',
             );
             if ($fix) {
-                $phpcsFile->fixer->addContent($closeParen, ' ');
+                // Grow the following token rather than the cast itself: on PHP 8.5 the whole
+                // cast is one token, so the inner-spacing fix would target the same index and
+                // one of the two changes would be dropped.
+                $phpcsFile->fixer->addContentBefore($nextToken, ' ');
             }
         } else {
             $nextNonWhitespace = $phpcsFile->findNext(Tokens::$emptyTokens, $nextToken, null, true);

--- a/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
@@ -20,11 +20,23 @@ use PHP_CodeSniffer\Util\Tokens;
 class PipeOperatorSpacingSniff implements Sniff
 {
     /**
+     * PHP 8.5 tokenizes `|>` as a single T_PIPE token. On older versions, and on PHP 8.5
+     * whenever the two characters are separated, it comes through as T_BITWISE_OR followed
+     * by T_GREATER_THAN. Both forms have to be registered.
+     *
      * @inheritDoc
      */
     public function register(): array
     {
-        return [T_BITWISE_OR];
+        $tokens = [T_BITWISE_OR];
+
+        if (defined('T_PIPE')) {
+            /** @var int $pipe */
+            $pipe = constant('T_PIPE');
+            $tokens[] = $pipe;
+        }
+
+        return $tokens;
     }
 
     /**
@@ -33,6 +45,14 @@ class PipeOperatorSpacingSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr): void
     {
         $tokens = $phpcsFile->getTokens();
+
+        // PHP 8.5+: the whole operator is a single token, so there is nothing in between.
+        if ($tokens[$stackPtr]['type'] === 'T_PIPE') {
+            $this->checkSpacingBefore($phpcsFile, $stackPtr);
+            $this->checkSpacingAfter($phpcsFile, $stackPtr);
+
+            return;
+        }
 
         // Check if this is part of a pipe operator (|>)
         $nextNonWhitespace = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
@@ -87,7 +107,10 @@ class PipeOperatorSpacingSniff implements Sniff
             $message = 'Expected at least 1 space before "|"; 0 found';
             $fix = $phpcsFile->addFixableError($message, $stackPtr, 'MissingBefore');
             if ($fix) {
-                $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+                // Grow the preceding token rather than the operator itself: on PHP 8.5 the
+                // whole `|>` is one token, so the "after" fix would target the same index and
+                // one of the two changes would be dropped.
+                $phpcsFile->fixer->addContent($stackPtr - 1, ' ');
             }
         } else {
             $content = $tokens[$stackPtr - 1]['content'];
@@ -106,38 +129,39 @@ class PipeOperatorSpacingSniff implements Sniff
      * Check that there's exactly one space after the pipe operator
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
-     * @param int $greaterThanPtr Pointer to the > token
+     * @param int $pipeEnd Pointer to the last token of the operator: the `>` on the two-token
+     *   form, or the whole `|>` token on PHP 8.5+.
      *
      * @return void
      */
-    protected function checkSpacingAfter(File $phpcsFile, int $greaterThanPtr): void
+    protected function checkSpacingAfter(File $phpcsFile, int $pipeEnd): void
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $greaterThanPtr + 1, null, true);
+        $nextIndex = $phpcsFile->findNext(T_WHITESPACE, $pipeEnd + 1, null, true);
         if (!$nextIndex) {
             return;
         }
 
         // Check if next token is on a different line
-        if ($tokens[$nextIndex]['line'] !== $tokens[$greaterThanPtr]['line']) {
+        if ($tokens[$nextIndex]['line'] !== $tokens[$pipeEnd]['line']) {
             return;
         }
 
-        if ($tokens[$greaterThanPtr + 1]['code'] !== T_WHITESPACE) {
+        if ($tokens[$pipeEnd + 1]['code'] !== T_WHITESPACE) {
             $message = 'Expected at least 1 space after ">"; 0 found';
-            $fix = $phpcsFile->addFixableError($message, $greaterThanPtr, 'MissingAfter');
+            $fix = $phpcsFile->addFixableError($message, $pipeEnd, 'MissingAfter');
             if ($fix) {
-                $phpcsFile->fixer->addContent($greaterThanPtr, ' ');
+                $phpcsFile->fixer->addContentBefore($pipeEnd + 1, ' ');
             }
         } else {
-            $content = $tokens[$greaterThanPtr + 1]['content'];
-            if ($content !== ' ' && $tokens[$nextIndex]['line'] === $tokens[$greaterThanPtr]['line']) {
+            $content = $tokens[$pipeEnd + 1]['content'];
+            if ($content !== ' ' && $tokens[$nextIndex]['line'] === $tokens[$pipeEnd]['line']) {
                 $message = 'Expected 1 space after ">", but %d found';
                 $data = [strlen($content)];
-                $fix = $phpcsFile->addFixableError($message, $greaterThanPtr, 'TooManyAfter', $data);
+                $fix = $phpcsFile->addFixableError($message, $pipeEnd, 'TooManyAfter', $data);
                 if ($fix) {
-                    $phpcsFile->fixer->replaceToken($greaterThanPtr + 1, ' ');
+                    $phpcsFile->fixer->replaceToken($pipeEnd + 1, ' ');
                 }
             }
         }

--- a/PhpCollective/ruleset.xml
+++ b/PhpCollective/ruleset.xml
@@ -192,15 +192,13 @@
 
     <rule ref="Squiz.Operators.ValidLogicalOperators"/>
 
-    <rule ref="Generic.PHP.DeprecatedFunctions">
-        <properties>
-            <property name="forbiddenFunctions" type="array">
-                <element key="delete" value="unset"/>
-                <element key="create_function" value="null"/>
-                <element key="each" value="null"/>
-            </property>
-        </properties>
-    </rule>
+    <!--
+        Do not set the `forbiddenFunctions` property here. The sniff populates it in its
+        constructor from the Reflection API (every internal function marked deprecated for
+        the running PHP version). Setting the property replaces that list instead of adding
+        to it, which silently disables the sniff.
+    -->
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.Formatting.SpaceAfterCast">
         <properties>
             <property name="spacing" value="0"/>
@@ -208,7 +206,22 @@
     </rule>
 
     <rule ref="Squiz.PHP.Eval"/>
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <!--
+        Setting the property replaces the sniff's defaults, so `sizeof` and `delete` have to be
+        repeated here. `create_function` and `each` live here rather than on
+        Generic.PHP.DeprecatedFunctions because that sniff builds its list from the running
+        PHP version, where both are long gone.
+    -->
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array">
+                <element key="sizeof" value="count"/>
+                <element key="delete" value="unset"/>
+                <element key="create_function" value="null"/>
+                <element key="each" value="null"/>
+            </property>
+        </properties>
+    </rule>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>

--- a/tests/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniffTest.php
@@ -17,7 +17,7 @@ class PipeOperatorSpacingSniffTest extends TestCase
      */
     public function testPipeOperatorSpacingSniffer(): void
     {
-        $this->assertSnifferFindsFixableErrors(new PipeOperatorSpacingSniff(), 10, 10);
+        $this->assertSnifferFindsFixableErrors(new PipeOperatorSpacingSniff(), 11, 11);
     }
 
     /**
@@ -25,6 +25,6 @@ class PipeOperatorSpacingSniffTest extends TestCase
      */
     public function testPipeOperatorSpacingFixer(): void
     {
-        $this->assertSnifferCanFixErrors(new PipeOperatorSpacingSniff(), 10);
+        $this->assertSnifferCanFixErrors(new PipeOperatorSpacingSniff(), 11);
     }
 }

--- a/tests/_data/PipeOperatorSpacing/after.php
+++ b/tests/_data/PipeOperatorSpacing/after.php
@@ -27,6 +27,9 @@ class PipeOperatorExample
         // Combination of issues
         $bad4 = $input |> trim(...) |> strtolower(...);
 
+        // Space between | and >
+        $bad5 = $input |> trim(...);
+
         return $output;
     }
 }

--- a/tests/_data/PipeOperatorSpacing/before.php
+++ b/tests/_data/PipeOperatorSpacing/before.php
@@ -27,6 +27,9 @@ class PipeOperatorExample
         // Combination of issues
         $bad4 = $input|>trim(...)  |>  strtolower(...);
 
+        // Space between | and >
+        $bad5 = $input | > trim(...);
+
         return $output;
     }
 }


### PR DESCRIPTION
Two independent ways the standard was checking less than it looked like it was checking.

### `Generic.PHP.DeprecatedFunctions` was disabled by its own configuration

The sniff has no static list. Its constructor walks `get_defined_functions()` and asks `ReflectionFunction::isDeprecated()`, so it tracks whatever the running PHP marks deprecated - automatically, per version. The ruleset set `forbiddenFunctions` to a three-entry array, and a ruleset property assignment *replaces* the value rather than extending it. The reflection-built list was discarded on every run.

Before:

```
$ phpcs --standard=Generic --sniffs=Generic.PHP.DeprecatedFunctions dep.php
 3 | ERROR | Function utf8_encode() has been deprecated

$ phpcs --standard=PhpCollective --sniffs=Generic.PHP.DeprecatedFunctions dep.php
(nothing)
```

The three entries were also a poor trade: `each` and `create_function` were removed in PHP 8.0, so reflection cannot see them either way, and `delete` was never a PHP function. They now sit on `Generic.PHP.ForbiddenFunctions`, whose list *is* a plain property and is the right home for removed-in-8.0 names. Its two defaults are repeated there because that override replaces too.

After, all five report:

```
 2 | ERROR | The use of function create_function() is forbidden
 3 | ERROR | The use of function each() is forbidden
 4 | ERROR | The use of function delete() is forbidden; use unset() instead
 5 | ERROR | The use of function sizeof() is forbidden; use count() instead
 6 | ERROR | Function utf8_encode() has been deprecated
```

### `VoidCast` and `PipeOperatorSpacing` matched nothing on PHP 8.5

Both sniffs target PHP 8.5 syntax, and both broke on the version that introduced it. PHP 8.5 collapses each construct into one token:

| source | PHP 8.4 tokens | PHP 8.5 tokens |
| --- | --- | --- |
| `(void)` | `T_OPEN_PARENTHESIS` `T_STRING` `T_CLOSE_PARENTHESIS` | `T_VOID_CAST` |
| `( void )` | same, with whitespace between | `T_VOID_CAST`, content `'( void )'` |
| `\|>` | `T_BITWISE_OR` `T_GREATER_THAN` | `T_PIPE` |
| `\| >` | `T_BITWISE_OR` `T_GREATER_THAN` | unchanged - still two tokens |

`register()` returned only the pre-8.5 shapes, so on 8.5 neither sniff was ever handed a token and every violation passed. Both now register both shapes. Inner cast whitespace moves into the token content on 8.5, so it is read from there instead of from surrounding tokens.

Two fixers needed a target change. Once the operator is a single token, `MissingBefore` and `MissingAfter` both mutated that same index and PHPCS dropped the second, yielding `|>trim(...)`. They now grow the neighboring token, which also keeps the pre-8.5 path correct.

The pipe fixture gains a `| >` case: on 8.5 that is the only input still reaching the two-token branch, so without it that branch would go uncovered on the newest version.

### CI

`8.5` joins the validation matrix, which is what would have caught this. That surfaced one PHPStan finding only visible when analyzing on 8.5: `getFileDocBlockLines()` accepted `?int` and used it as an array key. Both call sites already pass a non-null value, so the parameter is now `int`.
