### PR TITLE
Detect fully-qualified global function calls in the function-name sniffs

### DIFF
--- a/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
+++ b/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
@@ -50,6 +50,40 @@ abstract class AbstractSniff implements Sniff
     private static array $classNameCache = [];
 
     /**
+     * @return array<int>
+     */
+    protected function getGlobalFunctionNameTokenCodes(): array
+    {
+        return [T_STRING, T_NAME_FULLY_QUALIFIED];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return string|null
+     */
+    protected function getGlobalFunctionName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_STRING) {
+            return strtolower($tokens[$stackPtr]['content']);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== T_NAME_FULLY_QUALIFIED) {
+            return null;
+        }
+
+        $functionName = substr($tokens[$stackPtr]['content'], 1);
+        if (str_contains($functionName, '\\')) {
+            return null;
+        }
+
+        return strtolower($functionName);
+    }
+
+    /**
      * @param \PHP_CodeSniffer\Files\File $phpcsFile
      * @param int $stackPtr
      *

--- a/PhpCollective/Sniffs/PHP/DisallowFunctionsSniff.php
+++ b/PhpCollective/Sniffs/PHP/DisallowFunctionsSniff.php
@@ -8,12 +8,12 @@
 namespace PhpCollective\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCollective\Sniffs\AbstractSniffs\AbstractSniff;
 
 /**
  * Do not use functions that are problematic or not safe for upgrading.
  */
-class DisallowFunctionsSniff implements Sniff
+class DisallowFunctionsSniff extends AbstractSniff
 {
     /**
      * @var array<string>
@@ -30,7 +30,7 @@ class DisallowFunctionsSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_STRING];
+        return $this->getGlobalFunctionNameTokenCodes();
     }
 
     /**
@@ -52,12 +52,12 @@ class DisallowFunctionsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        $key = strtolower($tokenContent);
-        if (!isset(static::$disallowed[$key])) {
+        $key = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
+        if ($key === null || !isset(static::$disallowed[$key])) {
             return;
         }
 
+        $tokenContent = $tokens[$stackPtr]['content'];
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if (!$previous || in_array($tokens[$previous]['code'], static::$wrongTokens)) {
             return;
@@ -82,8 +82,7 @@ class DisallowFunctionsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        $key = strtolower($tokenContent);
+        $key = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
         if ($key !== 'implode') {
             return;
         }

--- a/PhpCollective/Sniffs/PHP/NoIsNullSniff.php
+++ b/PhpCollective/Sniffs/PHP/NoIsNullSniff.php
@@ -21,7 +21,7 @@ class NoIsNullSniff extends AbstractSniff
      */
     public function register(): array
     {
-        return [T_STRING];
+        return $this->getGlobalFunctionNameTokenCodes();
     }
 
     /**
@@ -33,11 +33,12 @@ class NoIsNullSniff extends AbstractSniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        if (strtolower($tokenContent) !== 'is_null') {
+        $functionName = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
+        if ($functionName !== 'is_null') {
             return;
         }
 
+        $tokenContent = $tokens[$stackPtr]['content'];
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;

--- a/PhpCollective/Sniffs/PHP/PhpSapiConstantSniff.php
+++ b/PhpCollective/Sniffs/PHP/PhpSapiConstantSniff.php
@@ -8,12 +8,12 @@
 namespace PhpCollective\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCollective\Sniffs\AbstractSniffs\AbstractSniff;
 
 /**
  * Always use PHP_SAPI constant instead of php_sapi_name() function.
  */
-class PhpSapiConstantSniff implements Sniff
+class PhpSapiConstantSniff extends AbstractSniff
 {
     /**
      * @var string
@@ -25,7 +25,7 @@ class PhpSapiConstantSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_STRING];
+        return $this->getGlobalFunctionNameTokenCodes();
     }
 
     /**
@@ -37,11 +37,12 @@ class PhpSapiConstantSniff implements Sniff
 
         $wrongTokens = [T_FUNCTION, T_OBJECT_OPERATOR, T_NEW, T_DOUBLE_COLON];
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        if (strtolower($tokenContent) !== 'php_sapi_name') {
+        $functionName = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
+        if ($functionName !== 'php_sapi_name') {
             return;
         }
 
+        $tokenContent = $tokens[$stackPtr]['content'];
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if ($previous === false || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;

--- a/PhpCollective/Sniffs/PHP/PreferCastOverFunctionSniff.php
+++ b/PhpCollective/Sniffs/PHP/PreferCastOverFunctionSniff.php
@@ -30,7 +30,7 @@ class PreferCastOverFunctionSniff extends AbstractSniff
      */
     public function register(): array
     {
-        return [T_STRING];
+        return $this->getGlobalFunctionNameTokenCodes();
     }
 
     /**
@@ -42,12 +42,12 @@ class PreferCastOverFunctionSniff extends AbstractSniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        $key = strtolower($tokenContent);
-        if (!isset(static::$matching[$key])) {
+        $key = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
+        if ($key === null || !isset(static::$matching[$key])) {
             return;
         }
 
+        $tokenContent = $tokens[$stackPtr]['content'];
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
         if ($previous === false || in_array($tokens[$previous]['code'], $wrongTokens, true)) {
             return;

--- a/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniff.php
+++ b/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniff.php
@@ -8,12 +8,12 @@
 namespace PhpCollective\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCollective\Sniffs\AbstractSniffs\AbstractSniff;
 
 /**
  * Do not use aliases or long forms of functions.
  */
-class RemoveFunctionAliasSniff implements Sniff
+class RemoveFunctionAliasSniff extends AbstractSniff
 {
     /**
      * @see http://php.net/manual/en/aliases.php
@@ -44,7 +44,7 @@ class RemoveFunctionAliasSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_STRING];
+        return $this->getGlobalFunctionNameTokenCodes();
     }
 
     /**
@@ -67,12 +67,12 @@ class RemoveFunctionAliasSniff implements Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $tokenContent = $tokens[$stackPtr]['content'];
-        $key = strtolower($tokenContent);
-        if (!isset(static::$matching[$key])) {
+        $key = $this->getGlobalFunctionName($phpcsFile, $stackPtr);
+        if ($key === null || !isset(static::$matching[$key])) {
             return;
         }
 
+        $tokenContent = $tokens[$stackPtr]['content'];
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if (!$previous || in_array($tokens[$previous]['code'], $wrongTokens)) {
             return;
@@ -83,10 +83,16 @@ class RemoveFunctionAliasSniff implements Sniff
             return;
         }
 
-        $error = 'Function name ' . $tokenContent . '() found, should be ' . static::$matching[$key] . '().';
+        // A fully qualified call keeps its leading backslash, in the message as well as in the fix.
+        $replacement = static::$matching[$key];
+        if ($tokens[$stackPtr]['code'] === T_NAME_FULLY_QUALIFIED) {
+            $replacement = '\\' . $replacement;
+        }
+
+        $error = 'Function name ' . $tokenContent . '() found, should be ' . $replacement . '().';
         $fix = $phpcsFile->addFixableError($error, $stackPtr, 'LongInvalid');
         if ($fix) {
-            $phpcsFile->fixer->replaceToken($stackPtr, static::$matching[$key]);
+            $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
         }
     }
 }

--- a/PhpCollective/Sniffs/PHP/VoidCastSniff.php
+++ b/PhpCollective/Sniffs/PHP/VoidCastSniff.php
@@ -227,9 +227,9 @@ class VoidCastSniff implements Sniff
                 'MissingSpaceAfter',
             );
             if ($fix) {
-                // Grow the following token rather than the cast itself: on PHP 8.5 the whole
-                // cast is one token, so the inner-spacing fix would target the same index and
-                // one of the two changes would be dropped.
+                // Grow a neighboring token rather than the cast itself. Both spacing fixes
+                // deliberately avoid the cast token because on PHP 8.5 the whole cast is a single
+                // token, and two mutations of one index in one fixer pass would collide.
                 $phpcsFile->fixer->addContentBefore($nextToken, ' ');
             }
         } else {

--- a/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/PipeOperatorSpacingSniff.php
@@ -107,9 +107,9 @@ class PipeOperatorSpacingSniff implements Sniff
             $message = 'Expected at least 1 space before "|"; 0 found';
             $fix = $phpcsFile->addFixableError($message, $stackPtr, 'MissingBefore');
             if ($fix) {
-                // Grow the preceding token rather than the operator itself: on PHP 8.5 the
-                // whole `|>` is one token, so the "after" fix would target the same index and
-                // one of the two changes would be dropped.
+                // Grow a neighboring token rather than the operator itself. Both spacing fixes
+                // deliberately avoid the `|>` token because on PHP 8.5 the whole operator is a
+                // single token, and two mutations of one index in one fixer pass would collide.
                 $phpcsFile->fixer->addContent($stackPtr - 1, ' ');
             }
         } else {

--- a/tests/PhpCollective/Sniffs/PHP/DisallowFunctionsSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/DisallowFunctionsSniffTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\PHP;
+
+use PhpCollective\Sniffs\PHP\DisallowFunctionsSniff;
+use PhpCollective\Test\TestCase;
+
+class DisallowFunctionsSniffTest extends TestCase
+{
+    /**
+     * The sniff ships with an empty list that projects fill in via the ruleset, so the tests have
+     * to populate it. It is static, so it has to be put back or it leaks into every later test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        DisallowFunctionsSniff::$disallowed = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDisallowFunctionsSniffer(): void
+    {
+        DisallowFunctionsSniff::$disallowed = ['pos' => 'Use current() instead'];
+
+        $this->assertSnifferFindsFixableErrors(new DisallowFunctionsSniff(), 2, 0);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDisallowFunctionsFixer(): void
+    {
+        DisallowFunctionsSniff::$disallowed = ['pos' => 'Use current() instead'];
+
+        $this->assertSnifferCanFixErrors(new DisallowFunctionsSniff(), 0);
+    }
+}

--- a/tests/PhpCollective/Sniffs/PHP/NoIsNullSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/NoIsNullSniffTest.php
@@ -17,7 +17,7 @@ class NoIsNullSniffTest extends TestCase
      */
     public function testNoIsNullSniffer(): void
     {
-        $this->assertSnifferFindsFixableErrors(new NoIsNullSniff(), 8, 8);
+        $this->assertSnifferFindsFixableErrors(new NoIsNullSniff(), 10, 10);
     }
 
     /**
@@ -25,6 +25,6 @@ class NoIsNullSniffTest extends TestCase
      */
     public function testNoIsNullFixer(): void
     {
-        $this->assertSnifferCanFixErrors(new NoIsNullSniff(), 8);
+        $this->assertSnifferCanFixErrors(new NoIsNullSniff(), 10);
     }
 }

--- a/tests/PhpCollective/Sniffs/PHP/PhpSapiConstantSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/PhpSapiConstantSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\PHP;
+
+use PhpCollective\Sniffs\PHP\PhpSapiConstantSniff;
+use PhpCollective\Test\TestCase;
+
+class PhpSapiConstantSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testPhpSapiConstantSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new PhpSapiConstantSniff(), 2, 2);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPhpSapiConstantFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new PhpSapiConstantSniff(), 2);
+    }
+}

--- a/tests/PhpCollective/Sniffs/PHP/PreferCastOverFunctionSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/PreferCastOverFunctionSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\PHP;
+
+use PhpCollective\Sniffs\PHP\PreferCastOverFunctionSniff;
+use PhpCollective\Test\TestCase;
+
+class PreferCastOverFunctionSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testPreferCastOverFunctionSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new PreferCastOverFunctionSniff(), 2, 2);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPreferCastOverFunctionFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new PreferCastOverFunctionSniff(), 2);
+    }
+}

--- a/tests/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniffTest.php
+++ b/tests/PhpCollective/Sniffs/PHP/RemoveFunctionAliasSniffTest.php
@@ -17,7 +17,7 @@ class RemoveFunctionAliasSniffTest extends TestCase
      */
     public function testRemoveFunctionAliasSniffer(): void
     {
-        $this->assertSnifferFindsFixableErrors(new RemoveFunctionAliasSniff(), 16, 16);
+        $this->assertSnifferFindsFixableErrors(new RemoveFunctionAliasSniff(), 18, 18);
     }
 
     /**
@@ -25,6 +25,6 @@ class RemoveFunctionAliasSniffTest extends TestCase
      */
     public function testRemoveFunctionAliasFixer(): void
     {
-        $this->assertSnifferCanFixErrors(new RemoveFunctionAliasSniff(), 16);
+        $this->assertSnifferCanFixErrors(new RemoveFunctionAliasSniff(), 18);
     }
 }

--- a/tests/_data/DisallowFunctions/after.php
+++ b/tests/_data/DisallowFunctions/after.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be reported.
+     */
+    public function namespacedFunctionForms(array $list): array
+    {
+        $plain = pos($list);
+        $fullyQualified = \pos($list);
+        $qualified = Foo\pos($list);
+        $relative = namespace\pos($list);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/DisallowFunctions/before.php
+++ b/tests/_data/DisallowFunctions/before.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be reported.
+     */
+    public function namespacedFunctionForms(array $list): array
+    {
+        $plain = pos($list);
+        $fullyQualified = \pos($list);
+        $qualified = Foo\pos($list);
+        $relative = namespace\pos($list);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/NoIsNull/after.php
+++ b/tests/_data/NoIsNull/after.php
@@ -67,4 +67,17 @@ class FixMe
     {
         return $x === null;
     }
+
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms($x): array
+    {
+        $plain = $x === null;
+        $fullyQualified = $x === null;
+        $qualified = Foo\is_null($x);
+        $relative = namespace\is_null($x);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
 }

--- a/tests/_data/NoIsNull/before.php
+++ b/tests/_data/NoIsNull/before.php
@@ -67,4 +67,17 @@ class FixMe
     {
         return is_null($x) !== false;
     }
+
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms($x): array
+    {
+        $plain = is_null($x);
+        $fullyQualified = \is_null($x);
+        $qualified = Foo\is_null($x);
+        $relative = namespace\is_null($x);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
 }

--- a/tests/_data/PhpSapiConstant/after.php
+++ b/tests/_data/PhpSapiConstant/after.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms(): array
+    {
+        $plain = PHP_SAPI;
+        $fullyQualified = PHP_SAPI;
+        $qualified = Foo\php_sapi_name();
+        $relative = namespace\php_sapi_name();
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/PhpSapiConstant/before.php
+++ b/tests/_data/PhpSapiConstant/before.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms(): array
+    {
+        $plain = php_sapi_name();
+        $fullyQualified = \php_sapi_name();
+        $qualified = Foo\php_sapi_name();
+        $relative = namespace\php_sapi_name();
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/PreferCastOverFunction/after.php
+++ b/tests/_data/PreferCastOverFunction/after.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms($value): array
+    {
+        $plain = (int)$value;
+        $fullyQualified = (int)$value;
+        $qualified = Foo\intval($value);
+        $relative = namespace\intval($value);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/PreferCastOverFunction/before.php
+++ b/tests/_data/PreferCastOverFunction/before.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PhpCollective;
+
+class FixMe
+{
+    /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms($value): array
+    {
+        $plain = intval($value);
+        $fullyQualified = \intval($value);
+        $qualified = Foo\intval($value);
+        $relative = namespace\intval($value);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+}

--- a/tests/_data/RemoveFunctionAlias/after.php
+++ b/tests/_data/RemoveFunctionAlias/after.php
@@ -36,6 +36,19 @@ class FixMe
     }
 
     /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms(array $list): array
+    {
+        $plain = current($list);
+        $fullyQualified = \current($list);
+        $qualified = Foo\pos($list);
+        $relative = namespace\pos($list);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+
+    /**
      * Resource and runtime aliases.
      */
     public function runtime($handle, string $file): void

--- a/tests/_data/RemoveFunctionAlias/before.php
+++ b/tests/_data/RemoveFunctionAlias/before.php
@@ -36,6 +36,19 @@ class FixMe
     }
 
     /**
+     * Only plain and fully-qualified global calls should be touched.
+     */
+    public function namespacedFunctionForms(array $list): array
+    {
+        $plain = pos($list);
+        $fullyQualified = \pos($list);
+        $qualified = Foo\pos($list);
+        $relative = namespace\pos($list);
+
+        return [$plain, $fullyQualified, $qualified, $relative];
+    }
+
+    /**
      * Resource and runtime aliases.
      */
     public function runtime($handle, string $file): void


### PR DESCRIPTION
Five sniffs match calls to global functions. All five registered `T_STRING` only, and since PHP 8.0 that is not how a namespaced name reaches a sniff.

```
\pos()            ->  T_NAME_FULLY_QUALIFIED   content '\pos'
Foo\pos()         ->  T_NAME_QUALIFIED         content 'Foo\pos'
namespace\pos()   ->  T_NAME_RELATIVE          content 'namespace\pos'
pos()             ->  T_STRING                 content 'pos'
```

So writing the leading backslash - the style that lets opcache resolve global functions at compile time - made the call invisible to `RemoveFunctionAlias`, `NoIsNull`, `PreferCastOverFunction`, `DisallowFunctions` and `PhpSapiConstant` alike.

### What is matched now

`T_NAME_FULLY_QUALIFIED` with a single segment, and nothing else. `Foo\pos()` and `namespace\pos()` call a *namespaced* function, not the global one, so flagging them would be a false positive. The shared lookup lives in `AbstractSniff`: resolve `T_STRING` as before, strip one leading backslash off a fully qualified name, return null if a separator remains.

End to end, on a file in `namespace App`:

```php
$a = \is_integer($x);        // flagged   -> \is_int($x)
$b = is_integer($x);         // flagged   -> is_int($x)
$c = Foo\is_integer($x);     // untouched
$d = \is_null($x);           // flagged   -> $x === null
$e = \php_sapi_name();       // flagged   -> PHP_SAPI
$f = new \Join();            // untouched
$g = \Foo\Bar\join(1, 2);    // untouched
```

### The backslash and the fixers

`replaceToken()` swaps the whole token, backslash included, so each fixer had to make a choice. `RemoveFunctionAlias` writes it back - in the error message too, so the suggestion matches what the fixer produces:

```
 4 | ERROR | [x] Function name \is_integer() found, should be \is_int().
 5 | ERROR | [x] Function name is_integer() found, should be is_int().
```

The others replace the call with a cast, a constant, or nothing, where the backslash must not survive.

### Tests

`DisallowFunctions`, `PhpSapiConstant` and `PreferCastOverFunction` had no tests at all. They get fixtures covering all four forms; `NoIsNull` and `RemoveFunctionAlias` gain the same four cases. 102 tests before, 108 after.

`DisallowFunctions` ships with an empty list that projects fill in through the ruleset, so its test populates the static property and puts it back in `tearDown()` - otherwise it would leak into every test that runs after it.

### Also here

Two fixer comments introduced in #71 described the collision hazard as if only one of the two spacing fixes had moved off the operator token. Both did. Reworded, as raised in review on that PR.
