### PR TITLE
Add smoke tests for ten untested fixing sniffs

### DIFF
--- a/tests/PhpCollective/Sniffs/Classes/MethodDeclarationSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Classes/MethodDeclarationSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Classes;
+
+use PhpCollective\Sniffs\Classes\MethodDeclarationSniff;
+use PhpCollective\Test\TestCase;
+
+class MethodDeclarationSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testMethodDeclarationSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new MethodDeclarationSniff(), 5, 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMethodDeclarationFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new MethodDeclarationSniff(), 4);
+    }
+}

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockStructureSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockStructureSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Commenting;
+
+use PhpCollective\Sniffs\Commenting\DocBlockStructureSniff;
+use PhpCollective\Test\TestCase;
+
+class DocBlockStructureSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testDocBlockStructureSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new DocBlockStructureSniff(), 3, 3);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocBlockStructureFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new DocBlockStructureSniff(), 3);
+    }
+}

--- a/tests/PhpCollective/Sniffs/Commenting/DocBlockTagGroupingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocBlockTagGroupingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Commenting;
+
+use PhpCollective\Sniffs\Commenting\DocBlockTagGroupingSniff;
+use PhpCollective\Test\TestCase;
+
+class DocBlockTagGroupingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testDocBlockTagGroupingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new DocBlockTagGroupingSniff(), 6, 6);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocBlockTagGroupingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new DocBlockTagGroupingSniff(), 6);
+    }
+}

--- a/tests/PhpCollective/Sniffs/Commenting/DocCommentSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Commenting/DocCommentSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Commenting;
+
+use PhpCollective\Sniffs\Commenting\DocCommentSniff;
+use PhpCollective\Test\TestCase;
+
+class DocCommentSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testDocCommentSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new DocCommentSniff(), 4, 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocCommentFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new DocCommentSniff(), 4);
+    }
+}

--- a/tests/PhpCollective/Sniffs/ControlStructures/ControlStructureSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/ControlStructures/ControlStructureSpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\ControlStructures;
+
+use PhpCollective\Sniffs\ControlStructures\ControlStructureSpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class ControlStructureSpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testControlStructureSpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new ControlStructureSpacingSniff(), 6, 6);
+    }
+
+    /**
+     * @return void
+     */
+    public function testControlStructureSpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new ControlStructureSpacingSniff(), 6);
+    }
+}

--- a/tests/PhpCollective/Sniffs/Testing/MockSniffTest.php
+++ b/tests/PhpCollective/Sniffs/Testing/MockSniffTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\Testing;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCollective\Sniffs\Testing\MockSniff;
+use PhpCollective\Test\TestCase;
+
+class MockSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testMockSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new MockSniff(), 6, 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMockFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new MockSniff(), 4);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Sniffs\Sniff $sniffer
+     *
+     * @return string
+     */
+    protected function getDummyFileBefore(Sniff $sniffer): string
+    {
+        $fixture = parent::getDummyFileBefore($sniffer);
+        $target = TMP . 'MockSniffFixtureTest.php';
+
+        if (!is_dir(TMP)) {
+            mkdir(TMP, 0770, true);
+        }
+
+        $contents = file_get_contents($fixture);
+        $this->assertIsString($contents);
+        $result = file_put_contents($target, $contents);
+        $this->assertIsInt($result);
+
+        return $target;
+    }
+}

--- a/tests/PhpCollective/Sniffs/WhiteSpace/ConcatenationSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/ConcatenationSpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\WhiteSpace;
+
+use PhpCollective\Sniffs\WhiteSpace\ConcatenationSpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class ConcatenationSpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testConcatenationSpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new ConcatenationSpacingSniff(), 4, 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConcatenationSpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new ConcatenationSpacingSniff(), 4);
+    }
+}

--- a/tests/PhpCollective/Sniffs/WhiteSpace/FunctionSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/FunctionSpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\WhiteSpace;
+
+use PhpCollective\Sniffs\WhiteSpace\FunctionSpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class FunctionSpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testFunctionSpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new FunctionSpacingSniff(), 2, 2);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFunctionSpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new FunctionSpacingSniff(), 2);
+    }
+}

--- a/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\WhiteSpace;
+
+use PhpCollective\Sniffs\WhiteSpace\ImplicitCastSpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class ImplicitCastSpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testImplicitCastSpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new ImplicitCastSpacingSniff(), 4, 4);
+    }
+
+    /**
+     * @return void
+     */
+    public function testImplicitCastSpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new ImplicitCastSpacingSniff(), 4);
+    }
+}

--- a/tests/PhpCollective/Sniffs/WhiteSpace/TernarySpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/TernarySpacingSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PhpCollective\Test\PhpCollective\Sniffs\WhiteSpace;
+
+use PhpCollective\Sniffs\WhiteSpace\TernarySpacingSniff;
+use PhpCollective\Test\TestCase;
+
+class TernarySpacingSniffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testTernarySpacingSniffer(): void
+    {
+        $this->assertSnifferFindsFixableErrors(new TernarySpacingSniff(), 7, 7);
+    }
+
+    /**
+     * @return void
+     */
+    public function testTernarySpacingFixer(): void
+    {
+        $this->assertSnifferCanFixErrors(new TernarySpacingSniff(), 7);
+    }
+}

--- a/tests/_data/ConcatenationSpacing/after.php
+++ b/tests/_data/ConcatenationSpacing/after.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class ConcatenationSpacingExample
+{
+    public function render(string $first, string $second): string
+    {
+        $missingBefore = $first . 'b';
+        $missingAfter = $first . 'b';
+        $tooManyBefore = $first . 'b';
+        $tooManyAfter = $first . 'b';
+
+        $valid = $first . 'b';
+        $multiline = $first
+            . $second;
+
+        return $missingBefore . $missingAfter . $tooManyBefore . $tooManyAfter . $valid . $multiline;
+    }
+}

--- a/tests/_data/ConcatenationSpacing/before.php
+++ b/tests/_data/ConcatenationSpacing/before.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class ConcatenationSpacingExample
+{
+    public function render(string $first, string $second): string
+    {
+        $missingBefore = $first. 'b';
+        $missingAfter = $first .'b';
+        $tooManyBefore = $first  . 'b';
+        $tooManyAfter = $first .  'b';
+
+        $valid = $first . 'b';
+        $multiline = $first
+            . $second;
+
+        return $missingBefore . $missingAfter . $tooManyBefore . $tooManyAfter . $valid . $multiline;
+    }
+}

--- a/tests/_data/ControlStructureSpacing/after.php
+++ b/tests/_data/ControlStructureSpacing/after.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+use RuntimeException;
+use Throwable;
+
+class ControlStructureSpacingExample
+{
+    public function run(): void
+    {
+        try {
+            throw new RuntimeException('first');
+        } catch (RuntimeException $exception) {
+        }
+
+        try {
+            throw new RuntimeException('second');
+        } catch (Throwable $exception) {
+        }
+
+        try {
+            throw new RuntimeException('valid');
+        } catch (Throwable $exception) {
+        }
+    }
+}

--- a/tests/_data/ControlStructureSpacing/before.php
+++ b/tests/_data/ControlStructureSpacing/before.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+use RuntimeException;
+use Throwable;
+
+class ControlStructureSpacingExample
+{
+    public function run(): void
+    {
+        try{
+            throw new RuntimeException('first');
+        }catch(RuntimeException $exception) {
+        }
+
+        try
+        {
+            throw new RuntimeException('second');
+        }
+        catch
+        (Throwable $exception) {
+        }
+
+        try {
+            throw new RuntimeException('valid');
+        } catch (Throwable $exception) {
+        }
+    }
+}

--- a/tests/_data/DocBlockStructure/after.php
+++ b/tests/_data/DocBlockStructure/after.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocBlockStructureExample
+{
+    /**
+     * Opening marker has too many stars.
+     */
+    public const OPENING = 'opening';
+
+    /**
+     * Closing marker has too many stars.
+     */
+    public const CLOSING = 'closing';
+
+    /**
+     * Summary starts on the opening line.
+     */
+    public const BEGINNING = 'beginning';
+
+    /** Single-line comments are left alone. */
+    public const VALID_SINGLE_LINE = 'valid';
+
+    /**
+     * Valid multi-line comments are left alone.
+     */
+    public const VALID_MULTI_LINE = 'valid';
+}

--- a/tests/_data/DocBlockStructure/before.php
+++ b/tests/_data/DocBlockStructure/before.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocBlockStructureExample
+{
+    /***
+     * Opening marker has too many stars.
+     */
+    public const OPENING = 'opening';
+
+    /**
+     * Closing marker has too many stars.
+     **/
+    public const CLOSING = 'closing';
+
+    /** Summary starts on the opening line.
+     */
+    public const BEGINNING = 'beginning';
+
+    /** Single-line comments are left alone. */
+    public const VALID_SINGLE_LINE = 'valid';
+
+    /**
+     * Valid multi-line comments are left alone.
+     */
+    public const VALID_MULTI_LINE = 'valid';
+}

--- a/tests/_data/DocBlockTagGrouping/after.php
+++ b/tests/_data/DocBlockTagGrouping/after.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocBlockTagGroupingExample
+{
+    /**
+     *
+     * @var string
+     */
+    public const TAGS_START_TOO_LATE = 'start';
+
+    /**
+     * Tags need one separating line.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function missingDescriptionTagSeparator(string $name): void
+    {
+    }
+
+    /**
+     * Same tags must stay together.
+     *
+     * @param string $first
+     * @param string $second
+     *
+     * @return void
+     */
+    public function sameTagsHaveExtraSpacing(string $first, string $second): void
+    {
+    }
+
+    /**
+     * Different tags need one separator.
+     *
+     * @param string $value
+     *
+     * @throws \RuntimeException
+     */
+    public function differentTagsNeedSpacing(string $value): void
+    {
+    }
+
+    /**
+     * Extra spacing after tags.
+     *
+     * @return void
+     */
+    public function tagsHaveTrailingSpacing(): void
+    {
+    }
+
+    /**
+     * Valid grouping.
+     *
+     * @param string $value
+     *
+     * @return void
+     */
+    public function validGrouping(string $value): void
+    {
+    }
+
+    public function closureIsLeftAlone(): void
+    {
+        /**
+         * Closure doc block is ignored.
+         * @return void
+         */
+        $closure = function (): void {
+        };
+    }
+}

--- a/tests/_data/DocBlockTagGrouping/before.php
+++ b/tests/_data/DocBlockTagGrouping/before.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocBlockTagGroupingExample
+{
+    /**
+     *
+     * @var string
+     */
+    public const TAGS_START_TOO_LATE = 'start';
+
+    /**
+     * Tags need one separating line.
+     * @param string $name
+     * @return void
+     */
+    public function missingDescriptionTagSeparator(string $name): void
+    {
+    }
+
+    /**
+     * Same tags must stay together.
+     *
+     * @param string $first
+     *
+     * @param string $second
+     *
+     * @return void
+     */
+    public function sameTagsHaveExtraSpacing(string $first, string $second): void
+    {
+    }
+
+    /**
+     * Different tags need one separator.
+     *
+     * @param string $value
+     * @throws \RuntimeException
+     */
+    public function differentTagsNeedSpacing(string $value): void
+    {
+    }
+
+    /**
+     * Extra spacing after tags.
+     *
+     * @return void
+     *
+     */
+    public function tagsHaveTrailingSpacing(): void
+    {
+    }
+
+    /**
+     * Valid grouping.
+     *
+     * @param string $value
+     *
+     * @return void
+     */
+    public function validGrouping(string $value): void
+    {
+    }
+
+    public function closureIsLeftAlone(): void
+    {
+        /**
+         * Closure doc block is ignored.
+         * @return void
+         */
+        $closure = function (): void {
+        };
+    }
+}

--- a/tests/_data/DocComment/after.php
+++ b/tests/_data/DocComment/after.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocCommentExample
+{
+    /**
+     * Close tag shares a line. 
+				 */
+    public function closeTagSharesLine(): void
+    {
+    }
+
+    /**
+     * Short description starts too late.
+     */
+    public function shortDescriptionStartsTooLate(): void
+    {
+    }
+
+    /**
+     * Extra blank line before the close tag.
+     */
+    public function extraBlankLineAtEnd(): void
+    {
+    }
+
+    /**
+     * Tags are too close.
+				 *
+     * @return void
+     */
+    public function tagsNeedSpacing(): void
+    {
+    }
+
+    /**
+     * Valid comment.
+     *
+     * @return void
+     */
+    public function validComment(): void
+    {
+    }
+}

--- a/tests/_data/DocComment/before.php
+++ b/tests/_data/DocComment/before.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class DocCommentExample
+{
+    /**
+     * Close tag shares a line. */
+    public function closeTagSharesLine(): void
+    {
+    }
+
+    /**
+     *
+     * Short description starts too late.
+     */
+    public function shortDescriptionStartsTooLate(): void
+    {
+    }
+
+    /**
+     * Extra blank line before the close tag.
+     *
+     */
+    public function extraBlankLineAtEnd(): void
+    {
+    }
+
+    /**
+     * Tags are too close.
+     * @return void
+     */
+    public function tagsNeedSpacing(): void
+    {
+    }
+
+    /**
+     * Valid comment.
+     *
+     * @return void
+     */
+    public function validComment(): void
+    {
+    }
+}

--- a/tests/_data/FunctionSpacing/after.php
+++ b/tests/_data/FunctionSpacing/after.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+interface FunctionSpacingContract
+{
+    public function first(): void;
+    public function second(): void;
+
+    public function last(): void;
+}
+
+class FunctionSpacingExample
+{
+    private string $name = 'x';
+
+    public function needsBlankBefore(): void
+    {
+    }
+
+    public function needsBlankAfter(): void
+    {
+    }
+
+    private string $other = 'y';
+
+    #[\Override]
+    public function attributeIsLeftAlone(): void
+    {
+    }
+
+    public function closureIsLeftAlone(): void
+    {
+        $closure = function (): void {
+        };
+    }
+}

--- a/tests/_data/FunctionSpacing/before.php
+++ b/tests/_data/FunctionSpacing/before.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+interface FunctionSpacingContract
+{
+    public function first(): void;
+    public function second(): void;
+
+    public function last(): void;
+}
+
+class FunctionSpacingExample
+{
+    private string $name = 'x';
+    public function needsBlankBefore(): void
+    {
+    }
+
+    public function needsBlankAfter(): void
+    {
+    }
+    private string $other = 'y';
+
+    #[\Override]
+    public function attributeIsLeftAlone(): void
+    {
+    }
+
+    public function closureIsLeftAlone(): void
+    {
+        $closure = function (): void {
+        };
+    }
+}

--- a/tests/_data/ImplicitCastSpacing/after.php
+++ b/tests/_data/ImplicitCastSpacing/after.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class ImplicitCastSpacingExample
+{
+    public function run(bool $ready, int $count, int $mask, callable $callable): int
+    {
+        $not = !$ready;
+        $silenced = @$callable();
+        $flipped = ~ $mask;
+        ++$count;
+        $count--;
+
+        $validNot = !$ready;
+        $validSilenced = @$callable();
+        ++$count;
+        $count++;
+
+        return (int)$not + (int)$silenced + $flipped + $count + (int)$validNot + (int)$validSilenced;
+    }
+}

--- a/tests/_data/ImplicitCastSpacing/before.php
+++ b/tests/_data/ImplicitCastSpacing/before.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class ImplicitCastSpacingExample
+{
+    public function run(bool $ready, int $count, int $mask, callable $callable): int
+    {
+        $not = ! $ready;
+        $silenced = @ $callable();
+        $flipped = ~ $mask;
+        ++ $count;
+        $count --;
+
+        $validNot = !$ready;
+        $validSilenced = @$callable();
+        ++$count;
+        $count++;
+
+        return (int)$not + (int)$silenced + $flipped + $count + (int)$validNot + (int)$validSilenced;
+    }
+}

--- a/tests/_data/MethodDeclaration/after.php
+++ b/tests/_data/MethodDeclaration/after.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+abstract class MethodDeclarationExample
+{
+    final public function finalAfterVisibility(): void
+    {
+    }
+
+    abstract public function abstractAfterVisibility(): void;
+
+    public static function staticBeforeVisibility(): void
+    {
+    }
+
+    final private function finalPrivate(): void
+    {
+    }
+
+    final public static function validOrder(): void
+    {
+    }
+}

--- a/tests/_data/MethodDeclaration/before.php
+++ b/tests/_data/MethodDeclaration/before.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+abstract class MethodDeclarationExample
+{
+    public final function finalAfterVisibility(): void
+    {
+    }
+
+    public abstract function abstractAfterVisibility(): void;
+
+    static public function staticBeforeVisibility(): void
+    {
+    }
+
+    private final function finalPrivate(): void
+    {
+    }
+
+    final public static function validOrder(): void
+    {
+    }
+}

--- a/tests/_data/Mock/after.php
+++ b/tests/_data/Mock/after.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class MockExampleTest
+{
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function missingMockReturnType()
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function invalidTypehint()
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function missingTypeHint(): Service
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|Repository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function complexMockMustNotHaveTypeHint(): Service
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    public function missingMockedClass()
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function validMock(): Service
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return RuntimeException
+     */
+    public function nonMockReturnType(): RuntimeException
+    {
+        return new RuntimeException('valid');
+    }
+}
+
+class Service
+{
+}
+
+class Repository
+{
+}

--- a/tests/_data/Mock/before.php
+++ b/tests/_data/Mock/before.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class MockExampleTest
+{
+    /**
+     * @return Service
+     */
+    public function missingMockReturnType(): MockObject
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function invalidTypehint(): MockObject
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function missingTypeHint()
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|Repository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function complexMockMustNotHaveTypeHint(): Service
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    public function missingMockedClass()
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return Service|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function validMock(): Service
+    {
+        return $this->createMock(Service::class);
+    }
+
+    /**
+     * @return RuntimeException
+     */
+    public function nonMockReturnType(): RuntimeException
+    {
+        return new RuntimeException('valid');
+    }
+}
+
+class Service
+{
+}
+
+class Repository
+{
+}

--- a/tests/_data/TernarySpacing/after.php
+++ b/tests/_data/TernarySpacing/after.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class TernarySpacingExample
+{
+    public function format(bool $first, bool $second, string $value): string
+    {
+        $missingBefore = $first ? 'yes' : 'no';
+        $missingAfter = $first ? 'yes' : 'no';
+        $missingElseBefore = $first ? 'yes' : 'no';
+        $missingElseAfter = $first ? 'yes' : 'no';
+        $tooManyBefore = $first ? 'yes' : 'no';
+        $tooManyAfter = $first ? 'yes' : 'no';
+        $short = $value ?: 'fallback';
+
+        $valid = $second ? 'left' : 'right';
+        $validShort = $value ?: 'fallback';
+        $multiline = $first
+            ? 'yes'
+            : 'no';
+
+        return $missingBefore . $missingAfter . $missingElseBefore . $missingElseAfter . $tooManyBefore . $tooManyAfter . $short . $valid . $validShort . $multiline;
+    }
+}

--- a/tests/_data/TernarySpacing/before.php
+++ b/tests/_data/TernarySpacing/before.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective;
+
+class TernarySpacingExample
+{
+    public function format(bool $first, bool $second, string $value): string
+    {
+        $missingBefore = $first? 'yes' : 'no';
+        $missingAfter = $first ?'yes' : 'no';
+        $missingElseBefore = $first ? 'yes': 'no';
+        $missingElseAfter = $first ? 'yes' :'no';
+        $tooManyBefore = $first  ? 'yes' : 'no';
+        $tooManyAfter = $first ?  'yes' : 'no';
+        $short = $value ? : 'fallback';
+
+        $valid = $second ? 'left' : 'right';
+        $validShort = $value ?: 'fallback';
+        $multiline = $first
+            ? 'yes'
+            : 'no';
+
+        return $missingBefore . $missingAfter . $missingElseBefore . $missingElseAfter . $tooManyBefore . $tooManyAfter . $short . $valid . $validShort . $multiline;
+    }
+}


### PR DESCRIPTION
86 sniffs, 38 test classes. The gap matters most for the sniffs that rewrite source: a fixer nobody exercises can break silently. That is not hypothetical - `VoidCast` and `PipeOperatorSpacing` had matched nothing at all on PHP 8.5 since the day they were written, and only #71 caught it.

This covers the ten heaviest rewriters, ranked by how many fixable errors they can emit:

| sniff | errors | fixable |
| --- | --- | --- |
| `TernarySpacing` | 7 | 7 |
| `Mock` | 6 | 4 |
| `DocBlockTagGrouping` | 6 | 6 |
| `ControlStructureSpacing` | 6 | 6 |
| `MethodDeclaration` | 5 | 4 |
| `DocComment` | 4 | 4 |
| `ConcatenationSpacing` | 4 | 4 |
| `ImplicitCastSpacing` | 4 | 4 |
| `DocBlockStructure` | 3 | 3 |
| `FunctionSpacing` | 2 | 2 |

Each fixture triggers the distinct error codes its sniff emits, and each also carries constructs the sniff must leave alone - a valid ternary, a correctly grouped docblock, a non-mock return type - so an over-eager matcher fails rather than passing quietly.

128 tests, up from 108.

### No behavior changes

Where a fixture documents something that looks wrong, it asserts what the sniff does today, not what it arguably should. Writing these turned up four such observations; the first is a real defect and gets its own PR:

- **`DocBlockTagGrouping`** reports `NoExtraNewlineBeforeTags` as fixable but never applies the fix. `checkBeginningOfDocBlock()` has `if ($fix) { return; }` where every sibling in the file uses `if (!$fix) { return; }`, so the fixer body runs only when the fixer is disabled.
- **`DocComment`** emits tab indentation when splitting a docblock, derived from the token column, regardless of the file's own indentation.
- **`FunctionSpacing`** has a dedicated branch for adjacent interface methods that the fixture never reaches.
- **`ImplicitCastSpacing`** does not flag `~ $mask`, though the `T_NONE` registration reads as if it might.
