### PR TITLE
Fix DocBlockTagGrouping reporting a fix it never applied

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocBlockTagGroupingSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocBlockTagGroupingSniff.php
@@ -175,7 +175,7 @@ class DocBlockTagGroupingSniff extends AbstractSniff
         }
 
         $fix = $phpcsFile->addFixableError('Expected no extra blank line before tags, got ' . ($diff - 1), $nextIndex, 'NoExtraNewlineBeforeTags');
-        if ($fix) {
+        if (!$fix) {
             return;
         }
 

--- a/tests/_data/DocBlockTagGrouping/after.php
+++ b/tests/_data/DocBlockTagGrouping/after.php
@@ -7,7 +7,6 @@ namespace PhpCollective;
 class DocBlockTagGroupingExample
 {
     /**
-     *
      * @var string
      */
     public const TAGS_START_TOO_LATE = 'start';


### PR DESCRIPTION
`checkBeginningOfDocBlock()` guarded its fixer body with the condition inverted:

```php
$fix = $phpcsFile->addFixableError(..., 'NoExtraNewlineBeforeTags');
if ($fix) {
    return;          // <- returns exactly when it should fix
}

$phpcsFile->fixer->beginChangeset();
```

`addFixableError()` returns true only while the fixer is running. So the changeset ran only when the fixer was disabled - a no-op - and phpcbf reported `NoExtraNewlineBeforeTags` as fixable and then changed nothing. Every other fixable error in the file uses `if (!$fix) { return; }`.

Found while writing the smoke fixtures in #73, which recorded the broken output:

```php
    /**
     *
     * @var string
     */
    public const TAGS_START_TOO_LATE = 'start';
```

The fixture now records the blank line actually being removed.
