### PR TITLE
Raise php_codesniffer minimum to 4.0.2 for CVE-2026-67434

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=8.1",
         "phpcsstandards/phpcsextra": "^1.5.0",
         "slevomat/coding-standard": "^8.23.0",
-        "squizlabs/php_codesniffer": "^4.0.1"
+        "squizlabs/php_codesniffer": "^4.0.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0.0",


### PR DESCRIPTION
The `prefer-lowest` job has been failing:

```
1 error (make sure you ran `composer update --prefer-lowest` before):
 - squizlabs/php_codesniffer: Defined `4.0.1.0` as minimum, but is `4.0.2.0`
```

That reads like a stale constraint, but the cause is a security advisory published on 2026-08-05:

```
| Package           | squizlabs/php_codesniffer                       |
| Advisory ID       | PKSA-rdkp-vv9z-mjkg                             |
| CVE               | CVE-2026-67434                                  |
| Title             | OS Command injection                            |
| Affected versions | <3.13.6|>=4.0.0,<4.0.2                          |
```

`composer.json` required `^4.0.1`, so a fresh install could pull an affected version. Composer will not resolve a package under an active advisory, so `--prefer-lowest` could not select the declared 4.0.1 minimum and landed on 4.0.2 - which is exactly the mismatch `validate-prefer-lowest` reports.

Raising the floor to `^4.0.2` fixes the advisory exposure and the job in one move.

```
$ composer audit
No security vulnerability advisories found.
```

Suite passes on 8.4 and 8.5 against 4.0.4, so the tokenizer changes between 4.0.1 and 4.0.4 do not affect any sniff here.
