### PR TITLE
Fix ConsistentIndent mis-indenting PHP 8.4 property hooks

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniff.php
@@ -65,7 +65,7 @@ class ConsistentIndentSniff extends AbstractSniff
         }
 
         // Get the expected indentation based on scope
-        $expectedIndent = $this->getExpectedIndent($tokens[$nextToken]);
+        $expectedIndent = $this->getExpectedIndent($phpcsFile, $nextToken, $tokens);
 
         // Skip anything that could be intentional (most things)
         if ($this->isInsideClosure($phpcsFile, $nextToken, $tokens)) {
@@ -180,15 +180,18 @@ class ConsistentIndentSniff extends AbstractSniff
     /**
      * Get the expected indentation level based on scope.
      *
-     * @param array<string, mixed> $token
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     * @param array<int, array<string, mixed>> $tokens
      *
      * @return int
      */
-    protected function getExpectedIndent(array $token): int
+    protected function getExpectedIndent(File $phpcsFile, int $stackPtr, array $tokens): int
     {
+        $token = $tokens[$stackPtr];
         $conditions = $token['conditions'];
 
-        return count($conditions);
+        return count($conditions) + $this->getUnscopedBraceIndent($phpcsFile, $stackPtr, $tokens);
     }
 
     /**
@@ -328,6 +331,17 @@ class ConsistentIndentSniff extends AbstractSniff
     private static array $arrowFunctionScopesCache = [];
 
     /**
+     * Per-file cache of paired curly-brace ranges that phpcs did not model as scopes.
+     *
+     * PHP 8.4 property hooks are one example: their braces have bracket
+     * opener/closer metadata, but they are not propagated through the
+     * `conditions` map. These ranges still affect block indentation.
+     *
+     * @var array<string, array{count: int, scopes: array<int, array{0: int, 1: int}>}>
+     */
+    private static array $unscopedBraceScopesCache = [];
+
+    /**
      * Check if the current position is inside a closure or arrow function.
      *
      * Fast path: phpcs's PHP tokenizer rewrites the `conditions` map of every
@@ -396,6 +410,73 @@ class ConsistentIndentSniff extends AbstractSniff
         }
 
         self::$arrowFunctionScopesCache[$cacheKey] = [
+            'count' => $tokenCount,
+            'scopes' => $scopes,
+        ];
+
+        return $scopes;
+    }
+
+    /**
+     * Count unscoped brace ranges enclosing the current token.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return int
+     */
+    protected function getUnscopedBraceIndent(File $phpcsFile, int $stackPtr, array $tokens): int
+    {
+        $indent = 0;
+        foreach ($this->getUnscopedBraceScopes($phpcsFile, $tokens) as $range) {
+            if ($stackPtr > $range[0] && $stackPtr < $range[1]) {
+                $indent++;
+            }
+        }
+
+        return $indent;
+    }
+
+    /**
+     * Build (and cache per file) unscoped paired curly-brace ranges.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param array<int, array<string, mixed>> $tokens
+     *
+     * @return array<int, array{0: int, 1: int}>
+     */
+    protected function getUnscopedBraceScopes(File $phpcsFile, array $tokens): array
+    {
+        $cacheKey = $phpcsFile->getFilename();
+        $tokenCount = count($tokens);
+        if (
+            isset(self::$unscopedBraceScopesCache[$cacheKey])
+            && self::$unscopedBraceScopesCache[$cacheKey]['count'] === $tokenCount
+        ) {
+            return self::$unscopedBraceScopesCache[$cacheKey]['scopes'];
+        }
+
+        $scopeOpeners = [];
+        foreach ($tokens as $token) {
+            if (isset($token['scope_opener'])) {
+                $scopeOpeners[$token['scope_opener']] = true;
+            }
+        }
+
+        $scopes = [];
+        foreach ($tokens as $stackPtr => $token) {
+            if ($token['code'] !== T_OPEN_CURLY_BRACKET) {
+                continue;
+            }
+            if (!isset($token['bracket_closer']) || isset($scopeOpeners[$stackPtr])) {
+                continue;
+            }
+
+            $scopes[] = [$stackPtr, $token['bracket_closer']];
+        }
+
+        self::$unscopedBraceScopesCache[$cacheKey] = [
             'count' => $tokenCount,
             'scopes' => $scopes,
         ];

--- a/tests/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/ConsistentIndentSniffTest.php
@@ -17,7 +17,7 @@ class ConsistentIndentSniffTest extends TestCase
      */
     public function testConsistentIndentSniffer(): void
     {
-        $this->assertSnifferFindsErrors(new ConsistentIndentSniff(), 2);
+        $this->assertSnifferFindsErrors(new ConsistentIndentSniff(), 3);
     }
 
     /**

--- a/tests/_data/ConsistentIndent/after.php
+++ b/tests/_data/ConsistentIndent/after.php
@@ -4,6 +4,22 @@ namespace PhpCollective;
 
 class FixMe
 {
+    public string $label = 'x' {
+        get {
+            return $this->label;
+        }
+        set {
+            $this->label = $value;
+        }
+    }
+
+    public string $misindentedLabel = 'x' {
+        set {
+            $this->misindentedLabel = $value;
+            $this->misindentedLabel = trim($this->misindentedLabel);
+        }
+    }
+
     public function orphanedIndentExample($params): array
     {
         if (!isset($params['url']['unresolved'])) {

--- a/tests/_data/ConsistentIndent/before.php
+++ b/tests/_data/ConsistentIndent/before.php
@@ -4,6 +4,22 @@ namespace PhpCollective;
 
 class FixMe
 {
+    public string $label = 'x' {
+        get {
+            return $this->label;
+        }
+        set {
+            $this->label = $value;
+        }
+    }
+
+    public string $misindentedLabel = 'x' {
+        set {
+            $this->misindentedLabel = $value;
+                $this->misindentedLabel = trim($this->misindentedLabel);
+        }
+    }
+
     public function orphanedIndentExample($params): array
     {
         if (!isset($params['url']['unresolved'])) {


### PR DESCRIPTION
`ConsistentIndent` dedents the second hook of a PHP 8.4 property hook block, and phpcbf applies it.

Input:

```php
class Hooks
{
    public string $label = 'x' {
        get {
            return $this->label;
        }
        set {
            $this->label = $value;
        }
    }
}
```

Reported, and auto-fixed:

```
 13 | ERROR | [x] Line indented incorrectly; expected 4 spaces, found 8 spaces
    |       |     (PhpCollective.WhiteSpace.ConsistentIndent.Incorrect)
```

Output - `set` moved to 4 while `get`, both bodies and every closing brace stayed at 8:

```php
        get {
            return $this->label;
        }
    set {
            $this->label = $value;
        }
```

### Cause

`getExpectedIndent()` returned `count($token['conditions'])`. PHP_CodeSniffer 4.x does not model property hooks as scopes - the hook braces get no `scope_opener`/`scope_closer` and add no entry to `conditions`. Dumping the parsed tokens shows every token inside both hooks carrying `conditions=[T_CLASS]`, so the whole block reads as one level deep.

Only the `set` line surfaced it. Lines whose previous content token is an opening brace pass the continuation check, and lines starting with `}` return early, which leaves exactly the line following the first hook's closing brace. A property with three hooks reports it twice.

### Fix

The braces are paired even though they are not scopes - they carry `bracket_opener` and `bracket_closer`. Expected indent now adds the number of enclosing curly-brace pairs that phpcs paired but did not map to a scope, so the depth model is repaired rather than special-cased for one syntax.

The ranges are collected in one pass and cached per file with the token count alongside, so the cache self-invalidates when phpcbf re-tokenizes mid fix-loop. That is the same approach already used for arrow function scopes, and it keeps the per-line cost off the file size.

### Coverage

The existing fixtures gain a correctly indented hook pair, which must come through byte-identical, and a deliberately misindented one, which proves the sniff still reports inside hook bodies instead of going blind there. Every pre-existing case in those fixtures is untouched - that is the regression guard on the depth-model change.
