### PR TITLE
Allow PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0.0",
-        "phpunit/phpunit": "^10.3 || ^11.2 || ^12.0"
+        "phpunit/phpunit": "^10.3 || ^11.2 || ^12.0 || ^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`require-dev` capped PHPUnit at `^12.0`, so no CI job ever ran the current major.

```
-"phpunit/phpunit": "^10.3 || ^11.2 || ^12.0"
+"phpunit/phpunit": "^10.3 || ^11.2 || ^12.0 || ^13.0"
```

PHPUnit 13 requires PHP 8.4, which the matrix has covered since #71 added 8.5. Composer resolves the highest compatible per job, so 8.1 keeps running 11 and the 8.4 and 8.5 jobs move to 13 - the whole supported range stays exercised rather than pinned to one major.

Verified locally against 13.2.6: 128 tests pass unchanged, and `phpunit.xml.dist` produces no schema warnings on the new major.
