### PR TITLE
Stop the function-name sniffs rewriting attribute names

### DIFF
--- a/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
+++ b/PhpCollective/Sniffs/AbstractSniffs/AbstractSniff.php
@@ -67,6 +67,13 @@ abstract class AbstractSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        // An attribute name sits in front of a parenthesis just like a call does, but it names a
+        // class. Every token between `#[` and its closer carries the opener, including grouped
+        // attributes after a comma.
+        if (isset($tokens[$stackPtr]['attribute_opener'])) {
+            return null;
+        }
+
         if ($tokens[$stackPtr]['code'] === T_STRING) {
             return strtolower($tokens[$stackPtr]['content']);
         }

--- a/tests/_data/RemoveFunctionAlias/after.php
+++ b/tests/_data/RemoveFunctionAlias/after.php
@@ -4,6 +4,13 @@ namespace PhpCollective;
 
 class FixMe
 {
+
+    /**
+     * Attribute names sit in front of a parenthesis but name a class, not a function.
+     */
+    #[Pos(1), Chop(2)]
+    #[\Join(3)]
+    public int $attributed = 1;
     /**
      * Type check aliases.
      */

--- a/tests/_data/RemoveFunctionAlias/before.php
+++ b/tests/_data/RemoveFunctionAlias/before.php
@@ -4,6 +4,13 @@ namespace PhpCollective;
 
 class FixMe
 {
+
+    /**
+     * Attribute names sit in front of a parenthesis but name a class, not a function.
+     */
+    #[Pos(1), Chop(2)]
+    #[\Join(3)]
+    public int $attributed = 1;
     /**
      * Type check aliases.
      */


### PR DESCRIPTION
The five function-name sniffs rewrote PHP attribute names into function calls.

```php
class Foo
{
    #[Pos(1), Chop(2)]
    #[\Join(3)]
    public int $x = 1;
}
```

Before:

```
 6 | ERROR | [x] Function name Pos() found, should be current().
 7 | ERROR | [x] Function name \Join() found, should be \implode().
```

Those are marked fixable, so phpcbf applied them - turning an attribute class `Pos` into `current()`. The result does not compile.

### Why the existing guard missed it

Each sniff rejects a match whose previous non-whitespace token is `T_FUNCTION`, `T_OBJECT_OPERATOR`, `T_NEW` or `T_DOUBLE_COLON`. An attribute name is preceded by `#[`, which is in none of them - and in a grouped attribute the second name follows a comma, so even adding `T_ATTRIBUTE` to that list would still miss `Chop` above.

Every token between an attribute opener and its closer carries `attribute_opener`, including names after a comma, so one check in the shared lookup in `AbstractSniff` covers all five sniffs and every position.

After, with a real call added to prove nothing was over-corrected:

```
 13 | ERROR | [x] Function name pos() found, should be current().
```

### Scope

This predates #72 for plain names - `#[Pos(1)]` was matched as `T_STRING` before. Adding fully-qualified support widened it to `#[\Join(3)]`. Both forms are now in the fixtures.
