### PR TITLE
Fix DocComment fixer emitting tab indentation

### DIFF
--- a/PhpCollective/Sniffs/Commenting/DocCommentSniff.php
+++ b/PhpCollective/Sniffs/Commenting/DocCommentSniff.php
@@ -75,8 +75,7 @@ class DocCommentSniff extends AbstractSniff
             $error = 'The close comment tag must be the only content on the line';
             $fix = $phpcsFile->addFixableError($error, $commentEnd, 'ContentBeforeClose');
             if ($fix === true) {
-                $indentation = $tokens[$commentStart]['column'] - 1;
-                $indentation = str_repeat("\t", $indentation);
+                $indentation = $this->getIndentationWhitespace($phpcsFile, $commentStart);
 
                 $phpcsFile->fixer->beginChangeset();
 
@@ -167,7 +166,7 @@ class DocCommentSniff extends AbstractSniff
                     $phpcsFile->fixer->replaceToken($i, '');
                 }
 
-                $indent = str_repeat("\t", $tokens[$stackPtr]['column'] - 1) . ' ';
+                $indent = $this->getIndentationWhitespace($phpcsFile, $stackPtr) . ' ';
                 $phpcsFile->fixer->addContent($prev, $phpcsFile->eolChar . $indent . '*' . $phpcsFile->eolChar);
                 $phpcsFile->fixer->endChangeset();
             }

--- a/tests/_data/DocComment/after.php
+++ b/tests/_data/DocComment/after.php
@@ -8,7 +8,7 @@ class DocCommentExample
 {
     /**
      * Close tag shares a line. 
-				 */
+     */
     public function closeTagSharesLine(): void
     {
     }
@@ -29,7 +29,7 @@ class DocCommentExample
 
     /**
      * Tags are too close.
-				 *
+     *
      * @return void
      */
     public function tagsNeedSpacing(): void


### PR DESCRIPTION
Two fixes in `DocCommentSniff` built indentation like this:

```php
$indentation = $tokens[$commentStart]['column'] - 1;
$indentation = str_repeat("\t", $indentation);
```

That is wrong in two ways at once.

**It emits tabs the standard forbids.** The ruleset enables `Generic.WhiteSpace.DisallowTabIndent`, so running phpcbf produced indentation that phpcs then reports:

```
 7 | ERROR | [x] Spaces must be used to indent lines; tabs are not allowed
   |       |     (Generic.WhiteSpace.DisallowTabIndent.TabsUsed)
```

**It uses a column offset as a repeat count.** A doc block indented one level with four spaces sits at column 5, so it emitted *four* tabs - four levels of indentation for a one-level block.

On a normal space-indented file, `/** Summary. @param string $a */` came out as:

```
    /** Summary. @param string $a
				 */
```

Both sites now use `getIndentationWhitespace()`, the helper already used for this in `DocBlockTagGrouping`, which reads the line's actual leading whitespace:

```
    /** Summary. @param string $a
     */
```

The `DocComment` fixture from #73 recorded the tab output as current behavior; it now records the file's own indentation. Regenerated from the fixer rather than hand-edited.
