### PR TITLE
Fix remaining falsy index guards and cache the unary lookup

### DIFF
--- a/PhpCollective/Sniffs/PHP/NoIsNullSniff.php
+++ b/PhpCollective/Sniffs/PHP/NoIsNullSniff.php
@@ -55,7 +55,7 @@ class NoIsNullSniff extends AbstractSniff
 
         $possibleCastIndex = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
 
-        if (!$possibleCastIndex) {
+        if ($possibleCastIndex === false) {
             return;
         }
 
@@ -156,7 +156,7 @@ class NoIsNullSniff extends AbstractSniff
         $tokens = $phpcsFile->getTokens();
 
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($index - 1), null, true);
-        if (!$previous) {
+        if ($previous === false) {
             return false;
         }
 
@@ -247,7 +247,7 @@ class NoIsNullSniff extends AbstractSniff
     {
         $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
 
-        if (!$previous) {
+        if ($previous === false) {
             return false;
         }
 

--- a/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -88,35 +88,39 @@ class ImplicitCastSpacingSniff implements Sniff
             return true;
         }
 
-        $unaryPrefixes = Tokens::$operators
-            + Tokens::$assignmentTokens
-            + Tokens::$comparisonTokens
-            + Tokens::$booleanOperators
-            + Tokens::$castTokens
-            + [
-                T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
-                T_OPEN_SQUARE_BRACKET => T_OPEN_SQUARE_BRACKET,
-                T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
-                T_OPEN_CURLY_BRACKET => T_OPEN_CURLY_BRACKET,
-                T_COMMA => T_COMMA,
-                T_SEMICOLON => T_SEMICOLON,
-                T_COLON => T_COLON,
-                T_DOUBLE_ARROW => T_DOUBLE_ARROW,
-                T_INLINE_THEN => T_INLINE_THEN,
-                T_INLINE_ELSE => T_INLINE_ELSE,
-                T_RETURN => T_RETURN,
-                T_ECHO => T_ECHO,
-                T_PRINT => T_PRINT,
-                T_CASE => T_CASE,
-                T_BOOLEAN_NOT => T_BOOLEAN_NOT,
-                T_YIELD => T_YIELD,
-                T_YIELD_FROM => T_YIELD_FROM,
-                T_THROW => T_THROW,
-                T_FN_ARROW => T_FN_ARROW,
-                T_MATCH_ARROW => T_MATCH_ARROW,
-                T_OPEN_TAG => T_OPEN_TAG,
-                T_OPEN_TAG_WITH_ECHO => T_OPEN_TAG_WITH_ECHO,
-            ];
+        static $unaryPrefixes = null;
+
+        if ($unaryPrefixes === null) {
+            $unaryPrefixes = Tokens::$operators
+                + Tokens::$assignmentTokens
+                + Tokens::$comparisonTokens
+                + Tokens::$booleanOperators
+                + Tokens::$castTokens
+                + [
+                    T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
+                    T_OPEN_SQUARE_BRACKET => T_OPEN_SQUARE_BRACKET,
+                    T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
+                    T_OPEN_CURLY_BRACKET => T_OPEN_CURLY_BRACKET,
+                    T_COMMA => T_COMMA,
+                    T_SEMICOLON => T_SEMICOLON,
+                    T_COLON => T_COLON,
+                    T_DOUBLE_ARROW => T_DOUBLE_ARROW,
+                    T_INLINE_THEN => T_INLINE_THEN,
+                    T_INLINE_ELSE => T_INLINE_ELSE,
+                    T_RETURN => T_RETURN,
+                    T_ECHO => T_ECHO,
+                    T_PRINT => T_PRINT,
+                    T_CASE => T_CASE,
+                    T_BOOLEAN_NOT => T_BOOLEAN_NOT,
+                    T_YIELD => T_YIELD,
+                    T_YIELD_FROM => T_YIELD_FROM,
+                    T_THROW => T_THROW,
+                    T_FN_ARROW => T_FN_ARROW,
+                    T_MATCH_ARROW => T_MATCH_ARROW,
+                    T_OPEN_TAG => T_OPEN_TAG,
+                    T_OPEN_TAG_WITH_ECHO => T_OPEN_TAG_WITH_ECHO,
+                ];
+        }
 
         return isset($unaryPrefixes[$tokens[$previousIndex]['code']]);
     }


### PR DESCRIPTION
Both points from Copilot's review of #80.

### `NoIsNull` skipped calls at the top of a file

```php
<?php is_null($x);        // not reported
```

```php
<?php
$y = 1;
is_null($x);              // reported
```

`findPrevious()` returns index `0` for the open tag, and `if (!$possibleCastIndex)` reads that as "nothing found". #80 fixed the same shape on the sniff's first guard; this one sits further down the same method, with two more like it. The two guards in that file that already compared against `false` are untouched.

### The unary lookup is built once

`isUnaryOperator()` rebuilt its prefix set on every call. That was cheap while the sniff only saw `!` and `@`, but it now registers `T_MINUS`, so it runs for every subtraction in a file. The set is constant, so it moves behind a `static`.
