### PR TITLE
Cover the reference operator in ImplicitCastSpacing

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -22,7 +22,7 @@ class ImplicitCastSpacingSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_BOOLEAN_NOT, T_NONE, T_ASPERAND, T_INC, T_DEC, T_MINUS];
+        return [T_BOOLEAN_NOT, T_NONE, T_ASPERAND, T_INC, T_DEC, T_MINUS, T_BITWISE_AND];
     }
 
     /**
@@ -35,6 +35,11 @@ class ImplicitCastSpacingSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_INC || $tokens[$stackPtr]['code'] === T_DEC) {
             $this->processIncDec($phpcsFile, $stackPtr);
 
+            return;
+        }
+
+        // `&` marks a reference here; as bitwise and it wants its spaces.
+        if ($tokens[$stackPtr]['code'] === T_BITWISE_AND && !$this->isReferenceOperator($phpcsFile, $stackPtr)) {
             return;
         }
 
@@ -63,6 +68,48 @@ class ImplicitCastSpacingSniff implements Sniff
             $phpcsFile->fixer->replaceToken($stackPtr + 1, '');
             $phpcsFile->fixer->endChangeset();
         }
+    }
+
+    /**
+     * `&` binds a reference rather than a bitwise and when it sits in front of a variable - or the
+     * ellipsis of a by-reference variadic - and
+     * either follows something that cannot end a value, or stands in a parameter list.
+     *
+     * The parameter list case needs its own test because a type hint precedes the marker in
+     * `function f(array & $items)`, and a type hint reads exactly like the left operand of a
+     * bitwise and. Requiring a variable on the right keeps a default such as
+     * `function f(int $x = A & B)` out of it.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $stackPtr
+     *
+     * @return bool
+     */
+    protected function isReferenceOperator(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $nextIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if ($nextIndex === false || !in_array($tokens[$nextIndex]['code'], [T_VARIABLE, T_ELLIPSIS], true)) {
+            return false;
+        }
+
+        if ($this->isUnaryOperator($phpcsFile, $stackPtr)) {
+            return true;
+        }
+
+        foreach ($tokens[$stackPtr]['nested_parenthesis'] ?? [] as $opener => $closer) {
+            if (!isset($tokens[$opener]['parenthesis_owner'])) {
+                continue;
+            }
+
+            $owner = $tokens[$opener]['parenthesis_owner'];
+            if (in_array($tokens[$owner]['code'], [T_FUNCTION, T_CLOSURE, T_FN], true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -111,6 +158,7 @@ class ImplicitCastSpacingSniff implements Sniff
                     T_ECHO => T_ECHO,
                     T_PRINT => T_PRINT,
                     T_CASE => T_CASE,
+                    T_AS => T_AS,
                     T_BOOLEAN_NOT => T_BOOLEAN_NOT,
                     T_YIELD => T_YIELD,
                     T_YIELD_FROM => T_YIELD_FROM,

--- a/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
@@ -17,7 +17,7 @@ class ImplicitCastSpacingSniffTest extends TestCase
      */
     public function testImplicitCastSpacingSniffer(): void
     {
-        $this->assertSnifferFindsFixableErrors(new ImplicitCastSpacingSniff(), 4, 4);
+        $this->assertSnifferFindsFixableErrors(new ImplicitCastSpacingSniff(), 8, 8);
     }
 
     /**
@@ -25,6 +25,6 @@ class ImplicitCastSpacingSniffTest extends TestCase
      */
     public function testImplicitCastSpacingFixer(): void
     {
-        $this->assertSnifferCanFixErrors(new ImplicitCastSpacingSniff(), 4);
+        $this->assertSnifferCanFixErrors(new ImplicitCastSpacingSniff(), 8);
     }
 }

--- a/tests/_data/ImplicitCastSpacing/after.php
+++ b/tests/_data/ImplicitCastSpacing/after.php
@@ -6,7 +6,7 @@ namespace PhpCollective;
 
 class ImplicitCastSpacingExample
 {
-    public function run(bool $ready, int $count, int $mask, callable $callable): int
+    public function run(bool $ready, int $count, int $mask, callable $callable, array $items): int
     {
         $not = !$ready;
         $silenced = @$callable();
@@ -23,9 +23,40 @@ class ImplicitCastSpacingExample
         $fqcnMinus = \PHP_INT_MAX - 1;
         $doubleNegated = - -$count;
         $arrow = fn (): int => -$count;
+        $reference = &$items;
+        $validReference = &$items;
+        $validBitwiseAnd = $count & $mask;
+
+        foreach ($items as &$item) {
+            $item = (int)$item;
+        }
+        unset($item);
+
+        $this->byRef($items);
 
         return (int)$not + (int)$silenced + $negated + $flipped + (int)$validNot
             + (int)$validSilenced + $validNegated + $validSubtraction
-            + $constantMinus + $boolMinus + $nullMinus + $fqcnMinus + $doubleNegated + $arrow();
+            + $constantMinus + $boolMinus + $nullMinus + $fqcnMinus + $doubleNegated + $arrow()
+            + count($reference) + count($validReference) + $validBitwiseAnd;
+    }
+
+    /**
+     * @param array<int> $items
+     *
+     * @return void
+     */
+    protected function byRef(array &$items): void
+    {
+        $items[] = 1;
+    }
+
+    /**
+     * @param int ...$args
+     *
+     * @return void
+     */
+    protected function byRefVariadic(&...$args): void
+    {
+        $args[] = 1;
     }
 }

--- a/tests/_data/ImplicitCastSpacing/before.php
+++ b/tests/_data/ImplicitCastSpacing/before.php
@@ -6,7 +6,7 @@ namespace PhpCollective;
 
 class ImplicitCastSpacingExample
 {
-    public function run(bool $ready, int $count, int $mask, callable $callable): int
+    public function run(bool $ready, int $count, int $mask, callable $callable, array $items): int
     {
         $not = ! $ready;
         $silenced = @ $callable();
@@ -23,9 +23,40 @@ class ImplicitCastSpacingExample
         $fqcnMinus = \PHP_INT_MAX - 1;
         $doubleNegated = - -$count;
         $arrow = fn (): int => - $count;
+        $reference = & $items;
+        $validReference = &$items;
+        $validBitwiseAnd = $count & $mask;
+
+        foreach ($items as & $item) {
+            $item = (int)$item;
+        }
+        unset($item);
+
+        $this->byRef($items);
 
         return (int)$not + (int)$silenced + $negated + $flipped + (int)$validNot
             + (int)$validSilenced + $validNegated + $validSubtraction
-            + $constantMinus + $boolMinus + $nullMinus + $fqcnMinus + $doubleNegated + $arrow();
+            + $constantMinus + $boolMinus + $nullMinus + $fqcnMinus + $doubleNegated + $arrow()
+            + count($reference) + count($validReference) + $validBitwiseAnd;
+    }
+
+    /**
+     * @param array<int> $items
+     *
+     * @return void
+     */
+    protected function byRef(array & $items): void
+    {
+        $items[] = 1;
+    }
+
+    /**
+     * @param int ...$args
+     *
+     * @return void
+     */
+    protected function byRefVariadic(& ...$args): void
+    {
+        $args[] = 1;
     }
 }


### PR DESCRIPTION
`- $a`, `! $b` and `@ f()` are already handled by `PhpCollective.WhiteSpace.ImplicitCastSpacing`. The reference marker is the same shape, so it joins that sniff rather than arriving as a new one.

This closes the last gap against `psr2r-sniffer`'s `UnaryOperatorSpacing`, which can now be deleted there - `&` was the only construct it still covered that this standard did not:

| Construct | PSR2R's sniff | this sniff, before | this sniff, after |
| --- | --- | --- | --- |
| `- $a` | yes | yes | yes |
| `! $b` | no | yes | yes |
| `@ f()` | yes | yes | yes |
| `& $list` | yes | **no** | yes |

### Reference or bitwise and

The preceding token is not enough on its own. In `function f(array & $items)` the marker follows a type hint, and a type hint looks exactly like the left operand of a bitwise and.

So a reference is a `&` that stands in front of a variable - or the ellipsis of a by-reference variadic - and either follows something that cannot end a value, or sits inside a parameter list. Requiring the variable on the right is what keeps a default value out of it:

```php
$bad = & $list;                                   // reported
foreach ($items as & $item) {}                    // reported
foreach ($items as $k => & $v) {}                 // reported
function f(array & $items) {}                     // reported
function g(& ...$args) {}                         // reported

$ok = &$list;                                     // untouched
$okBitwise = $a & $b;                             // untouched
$okBoolean = $a && $b;                            // untouched
function h(int $x = self::A & self::B) {}         // untouched
```

Every one of those is in the fixture.
