### PR TITLE
Cover return by reference in ImplicitCastSpacing

### DIFF
--- a/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
+++ b/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniff.php
@@ -89,6 +89,12 @@ class ImplicitCastSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        // Return by reference: `function & name()`. The name is not a variable, so this comes first.
+        $previousIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        if ($previousIndex !== false && in_array($tokens[$previousIndex]['code'], [T_FUNCTION, T_CLOSURE, T_FN], true)) {
+            return true;
+        }
+
         $nextIndex = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if ($nextIndex === false || !in_array($tokens[$nextIndex]['code'], [T_VARIABLE, T_ELLIPSIS], true)) {
             return false;

--- a/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
+++ b/tests/PhpCollective/Sniffs/WhiteSpace/ImplicitCastSpacingSniffTest.php
@@ -17,7 +17,7 @@ class ImplicitCastSpacingSniffTest extends TestCase
      */
     public function testImplicitCastSpacingSniffer(): void
     {
-        $this->assertSnifferFindsFixableErrors(new ImplicitCastSpacingSniff(), 8, 8);
+        $this->assertSnifferFindsFixableErrors(new ImplicitCastSpacingSniff(), 9, 9);
     }
 
     /**
@@ -25,6 +25,6 @@ class ImplicitCastSpacingSniffTest extends TestCase
      */
     public function testImplicitCastSpacingFixer(): void
     {
-        $this->assertSnifferCanFixErrors(new ImplicitCastSpacingSniff(), 8);
+        $this->assertSnifferCanFixErrors(new ImplicitCastSpacingSniff(), 9);
     }
 }

--- a/tests/_data/ImplicitCastSpacing/after.php
+++ b/tests/_data/ImplicitCastSpacing/after.php
@@ -59,4 +59,14 @@ class ImplicitCastSpacingExample
     {
         $args[] = 1;
     }
+
+    /**
+     * @return array<int>
+     */
+    protected function &byRefReturn(): array
+    {
+        static $items = [];
+
+        return $items;
+    }
 }

--- a/tests/_data/ImplicitCastSpacing/before.php
+++ b/tests/_data/ImplicitCastSpacing/before.php
@@ -59,4 +59,14 @@ class ImplicitCastSpacingExample
     {
         $args[] = 1;
     }
+
+    /**
+     * @return array<int>
+     */
+    protected function & byRefReturn(): array
+    {
+        static $items = [];
+
+        return $items;
+    }
 }


### PR DESCRIPTION
The reference marker added in #82 required a variable or a variadic ellipsis on the right, so a return-by-reference declaration slipped through - the thing on the right is a function name:

```php
public function & getItems(): array   // was not reported
```

That form is now checked first, keyed on the preceding `function` / `function () use` / `fn` keyword rather than on what follows.

Found while retiring `psr2r-sniffer`'s `UnaryOperatorSpacing` in favour of this sniff. Comparing the two against the same inputs, return by reference was the one construct the PSR2R sniff still reported that this one did not - removing it there would have quietly dropped the check.
